### PR TITLE
Structurize definitions

### DIFF
--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -1,0 +1,55 @@
+name: fhir.ts
+
+on: [push]
+
+jobs:
+  build:
+    name: Build fhir.ts
+    runs-on: ubuntu-18.04
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Cache node modules
+        uses: actions/cache@v1
+        with:
+          path: server/node_modules
+          key: ${{ runner.OS }}-${{ matrix.node-version}}-node-modules-${{ hashFiles('yarn.lock') }}
+
+      - name: Install Dependencies
+        run: yarn
+
+      - name: Build
+        run: yarn build
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Test
+        run: yarn test:ci
+
+  publish:
+    name: Build and publish
+    runs-on: ubuntu-18.04
+    needs: build
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Build
+        run: yarn build
+
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: yarn release

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,18 @@
+const config = {
+  preset: 'ts-jest',
+  moduleDirectories: ['node_modules', 'src'],
+  testEnvironment: 'node',
+  globals: {},
+}
+
+const unitTests = Object.assign(
+  {
+    displayName: 'Unit Tests',
+    testRegex: '.*\\.test\\.ts$',
+  },
+  config,
+)
+
+module.exports = {
+  projects: [unitTests],
+}

--- a/package.json
+++ b/package.json
@@ -7,19 +7,23 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "publish": "yarn publish --access public"
+    "publish": "yarn publish --access public",
+    "test": "jest --max-workers 1 --watch"
   },
   "dependencies": {},
   "devDependencies": {
+    "@types/jest": "^25.1.4",
     "@types/node": "^13.9.1",
     "@typescript-eslint/eslint-plugin": "^2.24.0",
     "@typescript-eslint/parser": "^2.24.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.0",
     "eslint-plugin-prettier": "^3.1.2",
+    "jest": "^25.1.0",
     "npm": "^6.14.2",
     "prettier": "^1.19.1",
     "semantic-release": "^17.0.4",
+    "ts-jest": "^25.2.1",
     "typescript": "^3.8.3"
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "publish": "yarn publish --access public",
-    "test": "jest --max-workers 1 --watch"
+    "lint": "eslint ./src/**/*.ts",
+    "release": "semantic-release",
+    "test": "jest --max-workers 1 --watch",
+    "test:ci": "jest --max-workers 1 --coverage"
   },
   "dependencies": {},
   "devDependencies": {
@@ -19,16 +21,33 @@
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.0",
     "eslint-plugin-prettier": "^3.1.2",
+    "husky": "^4.2.3",
     "jest": "^25.1.0",
     "npm": "^6.14.2",
     "prettier": "^1.19.1",
     "semantic-release": "^17.0.4",
     "ts-jest": "^25.2.1",
-    "typescript": "^3.8.3"
+    "typescript": "^3.8.3",
+    "validate-commit": "^3.4.0"
   },
   "prettier": {
     "singleQuote": true,
     "semi": false,
     "trailingComma": "all"
+  },
+  "release": {
+    "branch": "master",
+    "preset": "eslint",
+    "plugins": [
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      "@semantic-release/npm",
+      "@semantic-release/github"
+    ]
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "validate-commit-msg -p eslint"
+    }
   }
 }

--- a/src/attribute.ts
+++ b/src/attribute.ts
@@ -1,0 +1,125 @@
+import { AttributeDefinition } from 'types'
+
+const toCamelCase = (s: string) => s[0].toUpperCase() + s.slice(1)
+
+const PRIMITIVE_TYPES = [
+  'base64Binary',
+  'boolean',
+  'canonical',
+  'code',
+  'date',
+  'dateTime',
+  'decimal',
+  'id',
+  'instant',
+  'integer',
+  'markdown',
+  'oid',
+  'positiveInt',
+  'string',
+  'time',
+  'unsignedInt',
+  'uri',
+  'url',
+  'uuid',
+  'xhtml',
+]
+
+export class Attribute {
+  parent?: Attribute
+  children: Attribute[]
+  slices: Attribute[]
+
+  name: string
+  isArray: boolean
+  isSlice: boolean
+  isRequired: boolean
+  isPrimitive: boolean
+  definition: AttributeDefinition
+  types: string[]
+  index?: number
+
+  constructor(definition: AttributeDefinition, index?: number) {
+    this.children = []
+    this.slices = []
+
+    this.definition = definition
+    this.name = definition.id.split('.').pop()!
+    this.index = index
+    this.isArray = index === undefined && definition.max !== '1'
+    this.isSlice = !!definition.sliceName
+    this.isRequired = definition.min > 0
+
+    this.types = definition.type
+      ? definition.type.map((type: any) => type.code)
+      : []
+
+    this.isPrimitive =
+      this.types.length > 1
+        ? false
+        : PRIMITIVE_TYPES.includes(this.types[0])
+        ? true
+        : false
+  }
+
+  get isReferenceType(): boolean {
+    return this.types[0] === 'uri' && this.parent?.types[0] === 'Reference'
+  }
+
+  addChild(child: Attribute) {
+    child.parent = this
+    this.children.push(child)
+  }
+
+  addSlice(slice: Attribute) {
+    slice.parent = this.parent
+    this.slices.push(slice)
+  }
+
+  toJSON() {
+    return { ...this, parent: undefined }
+  }
+
+  equals(p: Attribute) {
+    return this.serialize() === p.serialize()
+  }
+
+  tail(): string {
+    // if element has an index, return the index in brackets
+    if (this.parent?.isArray) return `[${this.index || 0}]`
+
+    if (this.definition.sliceName && this.parent?.name.includes('[x]')) {
+      return this.definition.sliceName
+    }
+
+    // if the parent has multiple types, use the type in camelCase
+    if (this.parent && this.parent.types.length > 1)
+      return this.name.replace('[x]', toCamelCase(this.definition.type[0].code))
+
+    return this.name || ''
+  }
+
+  serialize(): string {
+    // if not parent, return the definitionId
+    if (!this.parent) {
+      return this.tail()
+    }
+
+    if (this.parent.isArray) {
+      return `${this.parent.serialize()}${this.tail()}`
+    }
+
+    // if parent is a multi-type attribute, we don't want to render the parent
+    if (
+      this.parent.types.length > 1 ||
+      (this.parent.definition.slicing && this.parent.name.includes('[x]'))
+    ) {
+      return this.parent.parent
+        ? `${this.parent.parent.serialize()}.${this.tail()}`
+        : this.tail()
+    }
+
+    // else, join the parent to the current element with a '.'
+    return `${this.parent.serialize()}.${this.tail()}`
+  }
+}

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -21,18 +21,13 @@ const metaProperties: (keyof ResourceDefinition)[] = [
 export const isSliceOf = (
   slice: AttributeDefinition,
   attr: AttributeDefinition,
-): boolean => {
-  return slice.path === attr.path && !!slice.sliceName
-}
+): boolean => slice.path === attr.path && !!slice.sliceName
 
 export const isChildOf = (
   child: AttributeDefinition,
   parent: AttributeDefinition,
-): boolean => {
-  const parentPath = parent.path.split('.')
-  const attrPath = child.path.split('.')
-  return JSON.stringify(attrPath.slice(0, -1)) === JSON.stringify(parentPath)
-}
+): boolean =>
+  child.path.substring(0, child.path.lastIndexOf('.')) === parent.path
 
 export const structurize = (fhirDefinition: {
   [k: string]: any

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -1,0 +1,123 @@
+import { Attribute } from './attribute'
+import { ResourceDefinition, Definition, AttributeDefinition } from 'types'
+
+const rootProperties: (keyof ResourceDefinition)[] = [
+  'min',
+  'max',
+  'constraint',
+]
+const metaProperties: (keyof ResourceDefinition)[] = [
+  'id',
+  'url',
+  'name',
+  'type',
+  'description',
+  'kind',
+  'baseDefinition',
+  'derivation',
+  'publisher',
+]
+
+export const isSliceOf = (
+  slice: AttributeDefinition,
+  attr: AttributeDefinition,
+): boolean => {
+  return slice.path === attr.path && !!slice.sliceName
+}
+
+export const isChildOf = (
+  child: AttributeDefinition,
+  parent: AttributeDefinition,
+): boolean => {
+  const parentPath = parent.path.split('.').slice(1)
+  const attrPath = child.path.split('.').slice(1)
+  return JSON.stringify(attrPath.slice(0, -1)) === JSON.stringify(parentPath)
+}
+
+export const structurize = (fhirDefinition: {
+  [k: string]: any
+}): Definition => {
+  if (!fhirDefinition.snapshot || !fhirDefinition.snapshot.element.length) {
+    throw new Error('Snapshot is needed in the structure definition.')
+  }
+
+  const buildMetadata = (): ResourceDefinition => {
+    const res = {} as ResourceDefinition
+
+    // Build the metadata structure on the definition object
+    for (const property of metaProperties) {
+      if (!fhirDefinition[property]) {
+        console.warn(`Missing property ${property} in StructureDefinition`)
+      }
+      res[property] = fhirDefinition[property]
+    }
+
+    // Extract the cardinality and constraints from the first element of the snapshot
+    for (const property of rootProperties) {
+      if (!fhirDefinition.snapshot.element[0][property]) {
+        console.warn(`Missing property ${property} in first snapshot attribute`)
+      }
+      res[property] = fhirDefinition.snapshot.element[0][property]
+    }
+    return res
+  }
+
+  const buildProperties = (): Attribute[] => {
+    // Iterate on the rest of the snapshot elements and add the properties on the definition object
+    // Note that we filter out the properties which are inherited from different resources (Resource, DomainResource...)
+    const recBuildProperties = (
+      attributes: AttributeDefinition[],
+      res: Attribute[],
+      current?: Attribute,
+    ): Attribute[] => {
+      const [next, ...rest] = attributes
+
+      // if the list of snapshot elements is over, return the attribute list
+      if (!next) {
+        return res
+      }
+
+      if (current) {
+        if (isSliceOf(next, current.definition)) {
+          const slice = new Attribute(next)
+          current.addSlice(slice)
+          // keep iterating on the snapshot elements using the slice attribute as current
+          return recBuildProperties(rest, res, slice)
+        }
+
+        // try to add the next attribute as child of the current one
+        if (isChildOf(next, current.definition)) {
+          const child = new Attribute(next)
+          current.addChild(child)
+          // keep iterating on the snapshot elements using the new child attribute as current
+          return recBuildProperties(rest, res, child)
+        }
+
+        // if next is not a children of current, try with the parent of current
+        return recBuildProperties([next, ...rest], res, current.parent)
+      }
+
+      // if there is no current attribute, append the attribute to the attributes list
+      const attr = new Attribute(next)
+      res.push(attr)
+
+      return recBuildProperties(rest, res, attr)
+    }
+
+    // Build the attributes ignoring the first element of the snapshot (which is not an actual attribute)
+    const cleanedSnapshot = fhirDefinition.snapshot.element.slice(1)
+    return recBuildProperties(cleanedSnapshot, [])
+  }
+
+  // If the structure defines a primitive type (one which we don't need to unroll in UI)
+  // we don't need additional properties, we only need the definition metadata.
+  if (fhirDefinition.kind === 'primitive-type')
+    return {
+      meta: buildMetadata(),
+    }
+
+  return {
+    meta: buildMetadata(),
+    attributes: buildProperties(),
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
-console.log('coucou')
+export { Attribute } from './attribute'
+export { structurize } from './definition'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,42 @@
+import { Attribute } from './attribute'
+
+export type Definition = {
+  meta: ResourceDefinition
+  attributes?: Attribute[]
+}
+
+export type Constraint = {
+  key: string
+  severity: string
+  human: string
+  expression: string
+  xpath: string
+  source: string
+}
+
+export type ResourceDefinition = {
+  id: string
+  url: string
+  name: string
+  type: string
+  description: string
+  kind: string
+  baseDefinition: string
+  derivation: string
+  publisher: string
+  min: string
+  max: string
+  constraint: Constraint[]
+}
+
+export type AttributeDefinition = {
+  id: string
+  path: string
+  definition: any
+  min: number
+  max: string
+  type: any[]
+  slicing: any
+  sliceName: string
+  constraint: Constraint[]
+}

--- a/tests/__snapshots__/definition.test.ts.snap
+++ b/tests/__snapshots__/definition.test.ts.snap
@@ -1,0 +1,5700 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`structurize builds a structured version of a mock StructureDefinition (snapshot) 1`] = `
+Object {
+  "attributes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "definition": Object {
+                "base": Object {
+                  "max": "1",
+                  "min": 0,
+                  "path": "Resource.id",
+                },
+                "id": "Mock.a.b.c",
+                "max": "1",
+                "min": 0,
+                "path": "Mock.a.b.c",
+                "type": Array [
+                  Object {
+                    "code": "string",
+                  },
+                ],
+              },
+              "index": undefined,
+              "isArray": false,
+              "isPrimitive": true,
+              "isRequired": false,
+              "isSlice": false,
+              "name": "c",
+              "parent": undefined,
+              "slices": Array [],
+              "types": Array [
+                "string",
+              ],
+            },
+          ],
+          "definition": Object {
+            "base": Object {
+              "max": "1",
+              "min": 0,
+              "path": "Resource.id",
+            },
+            "id": "Mock.a.b",
+            "max": "1",
+            "min": 0,
+            "path": "Mock.a.b",
+            "type": Array [
+              Object {
+                "code": "string",
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": false,
+          "isPrimitive": true,
+          "isRequired": false,
+          "isSlice": false,
+          "name": "b",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "string",
+          ],
+        },
+        Object {
+          "children": Array [],
+          "definition": Object {
+            "base": Object {
+              "max": "1",
+              "min": 0,
+              "path": "Resource.id",
+            },
+            "id": "Mock.a.d",
+            "max": "1",
+            "min": 0,
+            "path": "Mock.a.d",
+            "type": Array [
+              Object {
+                "code": "string",
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": false,
+          "isPrimitive": true,
+          "isRequired": false,
+          "isSlice": false,
+          "name": "d",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "string",
+          ],
+        },
+      ],
+      "definition": Object {
+        "base": Object {
+          "max": "1",
+          "min": 0,
+          "path": "Resource.id",
+        },
+        "id": "Mock.a",
+        "max": "1",
+        "min": 0,
+        "path": "Mock.a",
+        "type": Array [
+          Object {
+            "code": "string",
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": false,
+      "isPrimitive": true,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "a",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "string",
+      ],
+    },
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "definition": Object {
+            "base": Object {
+              "max": "1",
+              "min": 0,
+              "path": "Resource.id",
+            },
+            "id": "Mock.e.f",
+            "max": "1",
+            "min": 0,
+            "path": "Mock.e.f",
+            "type": Array [
+              Object {
+                "code": "string",
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": false,
+          "isPrimitive": true,
+          "isRequired": false,
+          "isSlice": false,
+          "name": "f",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "string",
+          ],
+        },
+      ],
+      "definition": Object {
+        "base": Object {
+          "max": "1",
+          "min": 0,
+          "path": "Resource.id",
+        },
+        "id": "Mock.e",
+        "max": "1",
+        "min": 0,
+        "path": "Mock.e",
+        "type": Array [
+          Object {
+            "code": "string",
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": false,
+      "isPrimitive": true,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "e",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "string",
+      ],
+    },
+  ],
+  "meta": Object {
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/super-mock",
+    "constraint": Array [
+      Object {
+        "expression": "contained.contained.empty()",
+        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+        "key": "dom-2",
+        "severity": "error",
+        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource",
+        "xpath": "not(parent::f:contained and f:contained)",
+      },
+    ],
+    "derivation": "constraint",
+    "description": "FHIR Heart Rate Profile",
+    "id": "mock",
+    "kind": "resource",
+    "max": "1",
+    "min": 0,
+    "name": "Mock",
+    "publisher": "Arkhn dev team",
+    "type": "Mock",
+    "url": "http://hl7.org/fhir/StructureDefinition/mock",
+  },
+}
+`;
+
+exports[`structurize builds a structured version of a real StructureDefinition (snapshot) 1`] = `
+Object {
+  "attributes": Array [
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "base": Object {
+          "max": "1",
+          "min": 0,
+          "path": "Resource.id",
+        },
+        "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+        "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+        "id": "Observation.id",
+        "isModifier": false,
+        "isSummary": true,
+        "max": "1",
+        "min": 0,
+        "path": "Observation.id",
+        "short": "Logical id of this artifact",
+        "type": Array [
+          Object {
+            "code": "http://hl7.org/fhirpath/System.String",
+            "extension": Array [
+              Object {
+                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                "valueUrl": "string",
+              },
+            ],
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": false,
+      "isPrimitive": false,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "id",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "http://hl7.org/fhirpath/System.String",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "base": Object {
+          "max": "1",
+          "min": 0,
+          "path": "Resource.meta",
+        },
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+        "id": "Observation.meta",
+        "isModifier": false,
+        "isSummary": true,
+        "max": "1",
+        "min": 0,
+        "path": "Observation.meta",
+        "short": "Metadata about the resource",
+        "type": Array [
+          Object {
+            "code": "Meta",
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": false,
+      "isPrimitive": false,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "meta",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "Meta",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "base": Object {
+          "max": "1",
+          "min": 0,
+          "path": "Resource.implicitRules",
+        },
+        "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+        "id": "Observation.implicitRules",
+        "isModifier": true,
+        "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+        "isSummary": true,
+        "max": "1",
+        "min": 0,
+        "path": "Observation.implicitRules",
+        "short": "A set of rules under which this content was created",
+        "type": Array [
+          Object {
+            "code": "uri",
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": false,
+      "isPrimitive": true,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "implicitRules",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "uri",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "base": Object {
+          "max": "1",
+          "min": 0,
+          "path": "Resource.language",
+        },
+        "binding": Object {
+          "description": "A human language.",
+          "extension": Array [
+            Object {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+              "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages",
+            },
+            Object {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+              "valueString": "Language",
+            },
+            Object {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+              "valueBoolean": true,
+            },
+          ],
+          "strength": "preferred",
+          "valueSet": "http://hl7.org/fhir/ValueSet/languages",
+        },
+        "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "The base language in which the resource is written.",
+        "id": "Observation.language",
+        "isModifier": false,
+        "isSummary": false,
+        "max": "1",
+        "min": 0,
+        "path": "Observation.language",
+        "short": "Language of the resource content",
+        "type": Array [
+          Object {
+            "code": "code",
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": false,
+      "isPrimitive": true,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "language",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "code",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "alias": Array [
+          "narrative",
+          "html",
+          "xhtml",
+          "display",
+        ],
+        "base": Object {
+          "max": "1",
+          "min": 0,
+          "path": "DomainResource.text",
+        },
+        "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \\"text blob\\" or where text is additionally entered raw or narrated and encoded information is added later.",
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \\"clinically safe\\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+        "id": "Observation.text",
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": Array [
+          Object {
+            "identity": "rim",
+            "map": "Act.text?",
+          },
+        ],
+        "max": "1",
+        "min": 0,
+        "path": "Observation.text",
+        "short": "Text summary of the resource, for human interpretation",
+        "type": Array [
+          Object {
+            "code": "Narrative",
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": false,
+      "isPrimitive": false,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "text",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "Narrative",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "alias": Array [
+          "inline resources",
+          "anonymous resources",
+          "contained resources",
+        ],
+        "base": Object {
+          "max": "*",
+          "min": 0,
+          "path": "DomainResource.contained",
+        },
+        "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+        "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+        "id": "Observation.contained",
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": Array [
+          Object {
+            "identity": "rim",
+            "map": "N/A",
+          },
+        ],
+        "max": "*",
+        "min": 0,
+        "path": "Observation.contained",
+        "short": "Contained, inline Resources",
+        "type": Array [
+          Object {
+            "code": "Resource",
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": true,
+      "isPrimitive": false,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "contained",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "Resource",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "alias": Array [
+          "extensions",
+          "user content",
+        ],
+        "base": Object {
+          "max": "*",
+          "min": 0,
+          "path": "DomainResource.extension",
+        },
+        "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+          Object {
+            "expression": "extension.exists() != value.exists()",
+            "human": "Must have either extensions or value[x], not both",
+            "key": "ext-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Extension",
+            "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \\"value\\")])",
+          },
+        ],
+        "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "id": "Observation.extension",
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": Array [
+          Object {
+            "identity": "rim",
+            "map": "N/A",
+          },
+        ],
+        "max": "*",
+        "min": 0,
+        "path": "Observation.extension",
+        "short": "Additional content defined by implementations",
+        "type": Array [
+          Object {
+            "code": "Extension",
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": true,
+      "isPrimitive": false,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "extension",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "Extension",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "alias": Array [
+          "extensions",
+          "user content",
+        ],
+        "base": Object {
+          "max": "*",
+          "min": 0,
+          "path": "DomainResource.modifierExtension",
+        },
+        "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+          Object {
+            "expression": "extension.exists() != value.exists()",
+            "human": "Must have either extensions or value[x], not both",
+            "key": "ext-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Extension",
+            "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \\"value\\")])",
+          },
+        ],
+        "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.
+
+Modifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+        "id": "Observation.modifierExtension",
+        "isModifier": true,
+        "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+        "isSummary": false,
+        "mapping": Array [
+          Object {
+            "identity": "rim",
+            "map": "N/A",
+          },
+        ],
+        "max": "*",
+        "min": 0,
+        "path": "Observation.modifierExtension",
+        "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+        "short": "Extensions that cannot be ignored",
+        "type": Array [
+          Object {
+            "code": "Extension",
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": true,
+      "isPrimitive": false,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "modifierExtension",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "Extension",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "base": Object {
+          "max": "*",
+          "min": 0,
+          "path": "Observation.identifier",
+        },
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "A unique identifier assigned to this observation.",
+        "id": "Observation.identifier",
+        "isModifier": false,
+        "isSummary": true,
+        "mapping": Array [
+          Object {
+            "identity": "workflow",
+            "map": "Event.identifier",
+          },
+          Object {
+            "identity": "w5",
+            "map": "FiveWs.identifier",
+          },
+          Object {
+            "identity": "v2",
+            "map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4.",
+          },
+          Object {
+            "identity": "rim",
+            "map": "id",
+          },
+        ],
+        "max": "*",
+        "min": 0,
+        "path": "Observation.identifier",
+        "requirements": "Allows observations to be distinguished and referenced.",
+        "short": "Business Identifier for observation",
+        "type": Array [
+          Object {
+            "code": "Identifier",
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": true,
+      "isPrimitive": false,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "identifier",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "Identifier",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "alias": Array [
+          "Fulfills",
+        ],
+        "base": Object {
+          "max": "*",
+          "min": 0,
+          "path": "Observation.basedOn",
+        },
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
+        "id": "Observation.basedOn",
+        "isModifier": false,
+        "isSummary": true,
+        "mapping": Array [
+          Object {
+            "identity": "workflow",
+            "map": "Event.basedOn",
+          },
+          Object {
+            "identity": "v2",
+            "map": "ORC",
+          },
+          Object {
+            "identity": "rim",
+            "map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]",
+          },
+        ],
+        "max": "*",
+        "min": 0,
+        "path": "Observation.basedOn",
+        "requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
+        "short": "Fulfills plan, proposal or order",
+        "type": Array [
+          Object {
+            "code": "Reference",
+            "targetProfile": Array [
+              "http://hl7.org/fhir/StructureDefinition/CarePlan",
+              "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+              "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+              "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+              "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+              "http://hl7.org/fhir/StructureDefinition/ServiceRequest",
+            ],
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": true,
+      "isPrimitive": false,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "basedOn",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "Reference",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "alias": Array [
+          "Container",
+        ],
+        "base": Object {
+          "max": "*",
+          "min": 0,
+          "path": "Observation.partOf",
+        },
+        "comment": "To link an Observation to an Encounter use \`encounter\`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
+        "id": "Observation.partOf",
+        "isModifier": false,
+        "isSummary": true,
+        "mapping": Array [
+          Object {
+            "identity": "workflow",
+            "map": "Event.partOf",
+          },
+          Object {
+            "identity": "v2",
+            "map": "Varies by domain",
+          },
+          Object {
+            "identity": "rim",
+            "map": ".outboundRelationship[typeCode=FLFS].target",
+          },
+        ],
+        "max": "*",
+        "min": 0,
+        "path": "Observation.partOf",
+        "short": "Part of referenced event",
+        "type": Array [
+          Object {
+            "code": "Reference",
+            "targetProfile": Array [
+              "http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
+              "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
+              "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+              "http://hl7.org/fhir/StructureDefinition/Procedure",
+              "http://hl7.org/fhir/StructureDefinition/Immunization",
+              "http://hl7.org/fhir/StructureDefinition/ImagingStudy",
+            ],
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": true,
+      "isPrimitive": false,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "partOf",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "Reference",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "base": Object {
+          "max": "1",
+          "min": 1,
+          "path": "Observation.status",
+        },
+        "binding": Object {
+          "extension": Array [
+            Object {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+              "valueString": "Status",
+            },
+          ],
+          "strength": "required",
+          "valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1",
+        },
+        "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "The status of the result value.",
+        "extension": Array [
+          Object {
+            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
+            "valueString": "default: final",
+          },
+        ],
+        "id": "Observation.status",
+        "isModifier": true,
+        "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+        "isSummary": true,
+        "mapping": Array [
+          Object {
+            "identity": "workflow",
+            "map": "Event.status",
+          },
+          Object {
+            "identity": "w5",
+            "map": "FiveWs.status",
+          },
+          Object {
+            "identity": "sct-concept",
+            "map": "< 445584004 |Report by finality status|",
+          },
+          Object {
+            "identity": "v2",
+            "map": "OBX-11",
+          },
+          Object {
+            "identity": "rim",
+            "map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \\"revise\\"",
+          },
+        ],
+        "max": "1",
+        "min": 1,
+        "mustSupport": true,
+        "path": "Observation.status",
+        "requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
+        "short": "registered | preliminary | final | amended +",
+        "type": Array [
+          Object {
+            "code": "code",
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": false,
+      "isPrimitive": true,
+      "isRequired": true,
+      "isSlice": false,
+      "name": "status",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "code",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "base": Object {
+          "max": "*",
+          "min": 0,
+          "path": "Observation.category",
+        },
+        "binding": Object {
+          "description": "Codes for high level observation categories.",
+          "extension": Array [
+            Object {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+              "valueString": "ObservationCategory",
+            },
+          ],
+          "strength": "preferred",
+          "valueSet": "http://hl7.org/fhir/ValueSet/observation-category",
+        },
+        "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "A code that classifies the general type of observation being made.",
+        "id": "Observation.category",
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": Array [
+          Object {
+            "identity": "w5",
+            "map": "FiveWs.class",
+          },
+          Object {
+            "identity": "rim",
+            "map": ".outboundRelationship[typeCode=\\"COMP].target[classCode=\\"LIST\\", moodCode=\\"EVN\\"].code",
+          },
+        ],
+        "max": "*",
+        "min": 1,
+        "mustSupport": true,
+        "path": "Observation.category",
+        "requirements": "Used for filtering what observations are retrieved and displayed.",
+        "short": "Classification of  type of observation",
+        "slicing": Object {
+          "discriminator": Array [
+            Object {
+              "path": "coding.code",
+              "type": "value",
+            },
+            Object {
+              "path": "coding.system",
+              "type": "value",
+            },
+          ],
+          "ordered": false,
+          "rules": "open",
+        },
+        "type": Array [
+          Object {
+            "code": "CodeableConcept",
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": true,
+      "isPrimitive": false,
+      "isRequired": true,
+      "isSlice": false,
+      "name": "category",
+      "parent": undefined,
+      "slices": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "definition": Object {
+                "base": Object {
+                  "max": "1",
+                  "min": 0,
+                  "path": "Element.id",
+                },
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "id": "Observation.category:VSCat.id",
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": Array [
+                  Object {
+                    "identity": "rim",
+                    "map": "n/a",
+                  },
+                ],
+                "max": "1",
+                "min": 0,
+                "path": "Observation.category.id",
+                "representation": Array [
+                  "xmlAttr",
+                ],
+                "short": "Unique id for inter-element referencing",
+                "type": Array [
+                  Object {
+                    "code": "http://hl7.org/fhirpath/System.String",
+                    "extension": Array [
+                      Object {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                        "valueUrl": "string",
+                      },
+                    ],
+                  },
+                ],
+              },
+              "index": undefined,
+              "isArray": false,
+              "isPrimitive": false,
+              "isRequired": false,
+              "isSlice": false,
+              "name": "id",
+              "parent": undefined,
+              "slices": Array [],
+              "types": Array [
+                "http://hl7.org/fhirpath/System.String",
+              ],
+            },
+            Object {
+              "children": Array [],
+              "definition": Object {
+                "alias": Array [
+                  "extensions",
+                  "user content",
+                ],
+                "base": Object {
+                  "max": "*",
+                  "min": 0,
+                  "path": "Element.extension",
+                },
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "constraint": Array [
+                  Object {
+                    "expression": "hasValue() or (children().count() > id.count())",
+                    "human": "All FHIR elements must have a @value or children",
+                    "key": "ele-1",
+                    "severity": "error",
+                    "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                    "xpath": "@value|f:*|h:div",
+                  },
+                  Object {
+                    "expression": "extension.exists() != value.exists()",
+                    "human": "Must have either extensions or value[x], not both",
+                    "key": "ext-1",
+                    "severity": "error",
+                    "source": "http://hl7.org/fhir/StructureDefinition/Extension",
+                    "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \\"value\\")])",
+                  },
+                ],
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "id": "Observation.category:VSCat.extension",
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": Array [
+                  Object {
+                    "identity": "rim",
+                    "map": "n/a",
+                  },
+                ],
+                "max": "*",
+                "min": 0,
+                "path": "Observation.category.extension",
+                "short": "Additional content defined by implementations",
+                "slicing": Object {
+                  "description": "Extensions are always sliced by (at least) url",
+                  "discriminator": Array [
+                    Object {
+                      "path": "url",
+                      "type": "value",
+                    },
+                  ],
+                  "rules": "open",
+                },
+                "type": Array [
+                  Object {
+                    "code": "Extension",
+                  },
+                ],
+              },
+              "index": undefined,
+              "isArray": true,
+              "isPrimitive": false,
+              "isRequired": false,
+              "isSlice": false,
+              "name": "extension",
+              "parent": undefined,
+              "slices": Array [],
+              "types": Array [
+                "Extension",
+              ],
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [],
+                  "definition": Object {
+                    "base": Object {
+                      "max": "1",
+                      "min": 0,
+                      "path": "Element.id",
+                    },
+                    "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                    "id": "Observation.category:VSCat.coding.id",
+                    "isModifier": false,
+                    "isSummary": false,
+                    "mapping": Array [
+                      Object {
+                        "identity": "rim",
+                        "map": "n/a",
+                      },
+                    ],
+                    "max": "1",
+                    "min": 0,
+                    "path": "Observation.category.coding.id",
+                    "representation": Array [
+                      "xmlAttr",
+                    ],
+                    "short": "Unique id for inter-element referencing",
+                    "type": Array [
+                      Object {
+                        "code": "http://hl7.org/fhirpath/System.String",
+                        "extension": Array [
+                          Object {
+                            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                            "valueUrl": "string",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  "index": undefined,
+                  "isArray": false,
+                  "isPrimitive": false,
+                  "isRequired": false,
+                  "isSlice": false,
+                  "name": "id",
+                  "parent": undefined,
+                  "slices": Array [],
+                  "types": Array [
+                    "http://hl7.org/fhirpath/System.String",
+                  ],
+                },
+                Object {
+                  "children": Array [],
+                  "definition": Object {
+                    "alias": Array [
+                      "extensions",
+                      "user content",
+                    ],
+                    "base": Object {
+                      "max": "*",
+                      "min": 0,
+                      "path": "Element.extension",
+                    },
+                    "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                    "constraint": Array [
+                      Object {
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "human": "All FHIR elements must have a @value or children",
+                        "key": "ele-1",
+                        "severity": "error",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                        "xpath": "@value|f:*|h:div",
+                      },
+                      Object {
+                        "expression": "extension.exists() != value.exists()",
+                        "human": "Must have either extensions or value[x], not both",
+                        "key": "ext-1",
+                        "severity": "error",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \\"value\\")])",
+                      },
+                    ],
+                    "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                    "id": "Observation.category:VSCat.coding.extension",
+                    "isModifier": false,
+                    "isSummary": false,
+                    "mapping": Array [
+                      Object {
+                        "identity": "rim",
+                        "map": "n/a",
+                      },
+                    ],
+                    "max": "*",
+                    "min": 0,
+                    "path": "Observation.category.coding.extension",
+                    "short": "Additional content defined by implementations",
+                    "slicing": Object {
+                      "description": "Extensions are always sliced by (at least) url",
+                      "discriminator": Array [
+                        Object {
+                          "path": "url",
+                          "type": "value",
+                        },
+                      ],
+                      "rules": "open",
+                    },
+                    "type": Array [
+                      Object {
+                        "code": "Extension",
+                      },
+                    ],
+                  },
+                  "index": undefined,
+                  "isArray": true,
+                  "isPrimitive": false,
+                  "isRequired": false,
+                  "isSlice": false,
+                  "name": "extension",
+                  "parent": undefined,
+                  "slices": Array [],
+                  "types": Array [
+                    "Extension",
+                  ],
+                },
+                Object {
+                  "children": Array [],
+                  "definition": Object {
+                    "base": Object {
+                      "max": "1",
+                      "min": 0,
+                      "path": "Coding.system",
+                    },
+                    "comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
+                    "constraint": Array [
+                      Object {
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "human": "All FHIR elements must have a @value or children",
+                        "key": "ele-1",
+                        "severity": "error",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                        "xpath": "@value|f:*|h:div",
+                      },
+                    ],
+                    "definition": "The identification of the code system that defines the meaning of the symbol in the code.",
+                    "fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
+                    "id": "Observation.category:VSCat.coding.system",
+                    "isModifier": false,
+                    "isSummary": true,
+                    "mapping": Array [
+                      Object {
+                        "identity": "v2",
+                        "map": "C*E.3",
+                      },
+                      Object {
+                        "identity": "rim",
+                        "map": "./codeSystem",
+                      },
+                      Object {
+                        "identity": "orim",
+                        "map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem",
+                      },
+                    ],
+                    "max": "1",
+                    "min": 1,
+                    "mustSupport": true,
+                    "path": "Observation.category.coding.system",
+                    "requirements": "Need to be unambiguous about the source of the definition of the symbol.",
+                    "short": "Identity of the terminology system",
+                    "type": Array [
+                      Object {
+                        "code": "uri",
+                      },
+                    ],
+                  },
+                  "index": undefined,
+                  "isArray": false,
+                  "isPrimitive": true,
+                  "isRequired": true,
+                  "isSlice": false,
+                  "name": "system",
+                  "parent": undefined,
+                  "slices": Array [],
+                  "types": Array [
+                    "uri",
+                  ],
+                },
+                Object {
+                  "children": Array [],
+                  "definition": Object {
+                    "base": Object {
+                      "max": "1",
+                      "min": 0,
+                      "path": "Coding.version",
+                    },
+                    "comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
+                    "constraint": Array [
+                      Object {
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "human": "All FHIR elements must have a @value or children",
+                        "key": "ele-1",
+                        "severity": "error",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                        "xpath": "@value|f:*|h:div",
+                      },
+                    ],
+                    "definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
+                    "id": "Observation.category:VSCat.coding.version",
+                    "isModifier": false,
+                    "isSummary": true,
+                    "mapping": Array [
+                      Object {
+                        "identity": "v2",
+                        "map": "C*E.7",
+                      },
+                      Object {
+                        "identity": "rim",
+                        "map": "./codeSystemVersion",
+                      },
+                      Object {
+                        "identity": "orim",
+                        "map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion",
+                      },
+                    ],
+                    "max": "1",
+                    "min": 0,
+                    "path": "Observation.category.coding.version",
+                    "short": "Version of the system - if relevant",
+                    "type": Array [
+                      Object {
+                        "code": "string",
+                      },
+                    ],
+                  },
+                  "index": undefined,
+                  "isArray": false,
+                  "isPrimitive": true,
+                  "isRequired": false,
+                  "isSlice": false,
+                  "name": "version",
+                  "parent": undefined,
+                  "slices": Array [],
+                  "types": Array [
+                    "string",
+                  ],
+                },
+                Object {
+                  "children": Array [],
+                  "definition": Object {
+                    "base": Object {
+                      "max": "1",
+                      "min": 0,
+                      "path": "Coding.code",
+                    },
+                    "constraint": Array [
+                      Object {
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "human": "All FHIR elements must have a @value or children",
+                        "key": "ele-1",
+                        "severity": "error",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                        "xpath": "@value|f:*|h:div",
+                      },
+                    ],
+                    "definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
+                    "fixedCode": "vital-signs",
+                    "id": "Observation.category:VSCat.coding.code",
+                    "isModifier": false,
+                    "isSummary": true,
+                    "mapping": Array [
+                      Object {
+                        "identity": "v2",
+                        "map": "C*E.1",
+                      },
+                      Object {
+                        "identity": "rim",
+                        "map": "./code",
+                      },
+                      Object {
+                        "identity": "orim",
+                        "map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code",
+                      },
+                    ],
+                    "max": "1",
+                    "min": 1,
+                    "mustSupport": true,
+                    "path": "Observation.category.coding.code",
+                    "requirements": "Need to refer to a particular code in the system.",
+                    "short": "Symbol in syntax defined by the system",
+                    "type": Array [
+                      Object {
+                        "code": "code",
+                      },
+                    ],
+                  },
+                  "index": undefined,
+                  "isArray": false,
+                  "isPrimitive": true,
+                  "isRequired": true,
+                  "isSlice": false,
+                  "name": "code",
+                  "parent": undefined,
+                  "slices": Array [],
+                  "types": Array [
+                    "code",
+                  ],
+                },
+                Object {
+                  "children": Array [],
+                  "definition": Object {
+                    "base": Object {
+                      "max": "1",
+                      "min": 0,
+                      "path": "Coding.display",
+                    },
+                    "constraint": Array [
+                      Object {
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "human": "All FHIR elements must have a @value or children",
+                        "key": "ele-1",
+                        "severity": "error",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                        "xpath": "@value|f:*|h:div",
+                      },
+                    ],
+                    "definition": "A representation of the meaning of the code in the system, following the rules of the system.",
+                    "extension": Array [
+                      Object {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true,
+                      },
+                    ],
+                    "id": "Observation.category:VSCat.coding.display",
+                    "isModifier": false,
+                    "isSummary": true,
+                    "mapping": Array [
+                      Object {
+                        "identity": "v2",
+                        "map": "C*E.2 - but note this is not well followed",
+                      },
+                      Object {
+                        "identity": "rim",
+                        "map": "CV.displayName",
+                      },
+                      Object {
+                        "identity": "orim",
+                        "map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName",
+                      },
+                    ],
+                    "max": "1",
+                    "min": 0,
+                    "path": "Observation.category.coding.display",
+                    "requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
+                    "short": "Representation defined by the system",
+                    "type": Array [
+                      Object {
+                        "code": "string",
+                      },
+                    ],
+                  },
+                  "index": undefined,
+                  "isArray": false,
+                  "isPrimitive": true,
+                  "isRequired": false,
+                  "isSlice": false,
+                  "name": "display",
+                  "parent": undefined,
+                  "slices": Array [],
+                  "types": Array [
+                    "string",
+                  ],
+                },
+                Object {
+                  "children": Array [],
+                  "definition": Object {
+                    "base": Object {
+                      "max": "1",
+                      "min": 0,
+                      "path": "Coding.userSelected",
+                    },
+                    "comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
+                    "constraint": Array [
+                      Object {
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "human": "All FHIR elements must have a @value or children",
+                        "key": "ele-1",
+                        "severity": "error",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                        "xpath": "@value|f:*|h:div",
+                      },
+                    ],
+                    "definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
+                    "id": "Observation.category:VSCat.coding.userSelected",
+                    "isModifier": false,
+                    "isSummary": true,
+                    "mapping": Array [
+                      Object {
+                        "identity": "v2",
+                        "map": "Sometimes implied by being first",
+                      },
+                      Object {
+                        "identity": "rim",
+                        "map": "CD.codingRationale",
+                      },
+                      Object {
+                        "identity": "orim",
+                        "map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\\\#true a [     fhir:source \\"true\\";     fhir:target dt:CDCoding.codingRationale\\\\#O   ]",
+                      },
+                    ],
+                    "max": "1",
+                    "min": 0,
+                    "path": "Observation.category.coding.userSelected",
+                    "requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
+                    "short": "If this coding was chosen directly by the user",
+                    "type": Array [
+                      Object {
+                        "code": "boolean",
+                      },
+                    ],
+                  },
+                  "index": undefined,
+                  "isArray": false,
+                  "isPrimitive": true,
+                  "isRequired": false,
+                  "isSlice": false,
+                  "name": "userSelected",
+                  "parent": undefined,
+                  "slices": Array [],
+                  "types": Array [
+                    "boolean",
+                  ],
+                },
+              ],
+              "definition": Object {
+                "base": Object {
+                  "max": "*",
+                  "min": 0,
+                  "path": "CodeableConcept.coding",
+                },
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "constraint": Array [
+                  Object {
+                    "expression": "hasValue() or (children().count() > id.count())",
+                    "human": "All FHIR elements must have a @value or children",
+                    "key": "ele-1",
+                    "severity": "error",
+                    "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                    "xpath": "@value|f:*|h:div",
+                  },
+                ],
+                "definition": "A reference to a code defined by a terminology system.",
+                "id": "Observation.category:VSCat.coding",
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": Array [
+                  Object {
+                    "identity": "v2",
+                    "map": "C*E.1-8, C*E.10-22",
+                  },
+                  Object {
+                    "identity": "rim",
+                    "map": "union(., ./translation)",
+                  },
+                  Object {
+                    "identity": "orim",
+                    "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding",
+                  },
+                ],
+                "max": "*",
+                "min": 1,
+                "mustSupport": true,
+                "path": "Observation.category.coding",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "short": "Code defined by a terminology system",
+                "type": Array [
+                  Object {
+                    "code": "Coding",
+                  },
+                ],
+              },
+              "index": undefined,
+              "isArray": true,
+              "isPrimitive": false,
+              "isRequired": true,
+              "isSlice": false,
+              "name": "coding",
+              "parent": undefined,
+              "slices": Array [],
+              "types": Array [
+                "Coding",
+              ],
+            },
+            Object {
+              "children": Array [],
+              "definition": Object {
+                "base": Object {
+                  "max": "1",
+                  "min": 0,
+                  "path": "CodeableConcept.text",
+                },
+                "comment": "Very often the text is the same as a displayName of one of the codings.",
+                "constraint": Array [
+                  Object {
+                    "expression": "hasValue() or (children().count() > id.count())",
+                    "human": "All FHIR elements must have a @value or children",
+                    "key": "ele-1",
+                    "severity": "error",
+                    "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                    "xpath": "@value|f:*|h:div",
+                  },
+                ],
+                "definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
+                "extension": Array [
+                  Object {
+                    "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                    "valueBoolean": true,
+                  },
+                ],
+                "id": "Observation.category:VSCat.text",
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": Array [
+                  Object {
+                    "identity": "v2",
+                    "map": "C*E.9. But note many systems use C*E.2 for this",
+                  },
+                  Object {
+                    "identity": "rim",
+                    "map": "./originalText[mediaType/code=\\"text/plain\\"]/data",
+                  },
+                  Object {
+                    "identity": "orim",
+                    "map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText",
+                  },
+                ],
+                "max": "1",
+                "min": 0,
+                "path": "Observation.category.text",
+                "requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
+                "short": "Plain text representation of the concept",
+                "type": Array [
+                  Object {
+                    "code": "string",
+                  },
+                ],
+              },
+              "index": undefined,
+              "isArray": false,
+              "isPrimitive": true,
+              "isRequired": false,
+              "isSlice": false,
+              "name": "text",
+              "parent": undefined,
+              "slices": Array [],
+              "types": Array [
+                "string",
+              ],
+            },
+          ],
+          "definition": Object {
+            "base": Object {
+              "max": "*",
+              "min": 0,
+              "path": "Observation.category",
+            },
+            "binding": Object {
+              "description": "Codes for high level observation categories.",
+              "extension": Array [
+                Object {
+                  "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                  "valueString": "ObservationCategory",
+                },
+              ],
+              "strength": "preferred",
+              "valueSet": "http://hl7.org/fhir/ValueSet/observation-category",
+            },
+            "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+            "constraint": Array [
+              Object {
+                "expression": "hasValue() or (children().count() > id.count())",
+                "human": "All FHIR elements must have a @value or children",
+                "key": "ele-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                "xpath": "@value|f:*|h:div",
+              },
+            ],
+            "definition": "A code that classifies the general type of observation being made.",
+            "id": "Observation.category:VSCat",
+            "isModifier": false,
+            "isSummary": false,
+            "mapping": Array [
+              Object {
+                "identity": "w5",
+                "map": "FiveWs.class",
+              },
+              Object {
+                "identity": "rim",
+                "map": ".outboundRelationship[typeCode=\\"COMP].target[classCode=\\"LIST\\", moodCode=\\"EVN\\"].code",
+              },
+            ],
+            "max": "1",
+            "min": 1,
+            "mustSupport": true,
+            "path": "Observation.category",
+            "requirements": "Used for filtering what observations are retrieved and displayed.",
+            "short": "Classification of  type of observation",
+            "sliceName": "VSCat",
+            "type": Array [
+              Object {
+                "code": "CodeableConcept",
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": false,
+          "isPrimitive": false,
+          "isRequired": true,
+          "isSlice": true,
+          "name": "category:VSCat",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "CodeableConcept",
+          ],
+        },
+      ],
+      "types": Array [
+        "CodeableConcept",
+      ],
+    },
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "definition": Object {
+            "base": Object {
+              "max": "1",
+              "min": 0,
+              "path": "Element.id",
+            },
+            "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+            "id": "Observation.code.id",
+            "isModifier": false,
+            "isSummary": false,
+            "mapping": Array [
+              Object {
+                "identity": "rim",
+                "map": "n/a",
+              },
+            ],
+            "max": "1",
+            "min": 0,
+            "path": "Observation.code.id",
+            "representation": Array [
+              "xmlAttr",
+            ],
+            "short": "Unique id for inter-element referencing",
+            "type": Array [
+              Object {
+                "code": "http://hl7.org/fhirpath/System.String",
+                "extension": Array [
+                  Object {
+                    "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                    "valueUrl": "string",
+                  },
+                ],
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": false,
+          "isPrimitive": false,
+          "isRequired": false,
+          "isSlice": false,
+          "name": "id",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "http://hl7.org/fhirpath/System.String",
+          ],
+        },
+        Object {
+          "children": Array [],
+          "definition": Object {
+            "alias": Array [
+              "extensions",
+              "user content",
+            ],
+            "base": Object {
+              "max": "*",
+              "min": 0,
+              "path": "Element.extension",
+            },
+            "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+            "constraint": Array [
+              Object {
+                "expression": "hasValue() or (children().count() > id.count())",
+                "human": "All FHIR elements must have a @value or children",
+                "key": "ele-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                "xpath": "@value|f:*|h:div",
+              },
+              Object {
+                "expression": "extension.exists() != value.exists()",
+                "human": "Must have either extensions or value[x], not both",
+                "key": "ext-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Extension",
+                "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \\"value\\")])",
+              },
+            ],
+            "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+            "id": "Observation.code.extension",
+            "isModifier": false,
+            "isSummary": false,
+            "mapping": Array [
+              Object {
+                "identity": "rim",
+                "map": "n/a",
+              },
+            ],
+            "max": "*",
+            "min": 0,
+            "path": "Observation.code.extension",
+            "short": "Additional content defined by implementations",
+            "slicing": Object {
+              "description": "Extensions are always sliced by (at least) url",
+              "discriminator": Array [
+                Object {
+                  "path": "url",
+                  "type": "value",
+                },
+              ],
+              "rules": "open",
+            },
+            "type": Array [
+              Object {
+                "code": "Extension",
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": true,
+          "isPrimitive": false,
+          "isRequired": false,
+          "isSlice": false,
+          "name": "extension",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "Extension",
+          ],
+        },
+        Object {
+          "children": Array [],
+          "definition": Object {
+            "base": Object {
+              "max": "*",
+              "min": 0,
+              "path": "CodeableConcept.coding",
+            },
+            "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+            "constraint": Array [
+              Object {
+                "expression": "hasValue() or (children().count() > id.count())",
+                "human": "All FHIR elements must have a @value or children",
+                "key": "ele-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                "xpath": "@value|f:*|h:div",
+              },
+            ],
+            "definition": "A reference to a code defined by a terminology system.",
+            "id": "Observation.code.coding",
+            "isModifier": false,
+            "isSummary": true,
+            "mapping": Array [
+              Object {
+                "identity": "v2",
+                "map": "C*E.1-8, C*E.10-22",
+              },
+              Object {
+                "identity": "rim",
+                "map": "union(., ./translation)",
+              },
+              Object {
+                "identity": "orim",
+                "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding",
+              },
+            ],
+            "max": "*",
+            "min": 0,
+            "path": "Observation.code.coding",
+            "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+            "short": "Code defined by a terminology system",
+            "slicing": Object {
+              "discriminator": Array [
+                Object {
+                  "path": "code",
+                  "type": "value",
+                },
+                Object {
+                  "path": "system",
+                  "type": "value",
+                },
+              ],
+              "ordered": false,
+              "rules": "open",
+            },
+            "type": Array [
+              Object {
+                "code": "Coding",
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": true,
+          "isPrimitive": false,
+          "isRequired": false,
+          "isSlice": false,
+          "name": "coding",
+          "parent": undefined,
+          "slices": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [],
+                  "definition": Object {
+                    "base": Object {
+                      "max": "1",
+                      "min": 0,
+                      "path": "Element.id",
+                    },
+                    "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                    "id": "Observation.code.coding:HeartRateCode.id",
+                    "isModifier": false,
+                    "isSummary": false,
+                    "mapping": Array [
+                      Object {
+                        "identity": "rim",
+                        "map": "n/a",
+                      },
+                    ],
+                    "max": "1",
+                    "min": 0,
+                    "path": "Observation.code.coding.id",
+                    "representation": Array [
+                      "xmlAttr",
+                    ],
+                    "short": "Unique id for inter-element referencing",
+                    "type": Array [
+                      Object {
+                        "code": "http://hl7.org/fhirpath/System.String",
+                        "extension": Array [
+                          Object {
+                            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                            "valueUrl": "string",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  "index": undefined,
+                  "isArray": false,
+                  "isPrimitive": false,
+                  "isRequired": false,
+                  "isSlice": false,
+                  "name": "id",
+                  "parent": undefined,
+                  "slices": Array [],
+                  "types": Array [
+                    "http://hl7.org/fhirpath/System.String",
+                  ],
+                },
+                Object {
+                  "children": Array [],
+                  "definition": Object {
+                    "alias": Array [
+                      "extensions",
+                      "user content",
+                    ],
+                    "base": Object {
+                      "max": "*",
+                      "min": 0,
+                      "path": "Element.extension",
+                    },
+                    "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                    "constraint": Array [
+                      Object {
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "human": "All FHIR elements must have a @value or children",
+                        "key": "ele-1",
+                        "severity": "error",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                        "xpath": "@value|f:*|h:div",
+                      },
+                      Object {
+                        "expression": "extension.exists() != value.exists()",
+                        "human": "Must have either extensions or value[x], not both",
+                        "key": "ext-1",
+                        "severity": "error",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \\"value\\")])",
+                      },
+                    ],
+                    "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                    "id": "Observation.code.coding:HeartRateCode.extension",
+                    "isModifier": false,
+                    "isSummary": false,
+                    "mapping": Array [
+                      Object {
+                        "identity": "rim",
+                        "map": "n/a",
+                      },
+                    ],
+                    "max": "*",
+                    "min": 0,
+                    "path": "Observation.code.coding.extension",
+                    "short": "Additional content defined by implementations",
+                    "slicing": Object {
+                      "description": "Extensions are always sliced by (at least) url",
+                      "discriminator": Array [
+                        Object {
+                          "path": "url",
+                          "type": "value",
+                        },
+                      ],
+                      "rules": "open",
+                    },
+                    "type": Array [
+                      Object {
+                        "code": "Extension",
+                      },
+                    ],
+                  },
+                  "index": undefined,
+                  "isArray": true,
+                  "isPrimitive": false,
+                  "isRequired": false,
+                  "isSlice": false,
+                  "name": "extension",
+                  "parent": undefined,
+                  "slices": Array [],
+                  "types": Array [
+                    "Extension",
+                  ],
+                },
+                Object {
+                  "children": Array [],
+                  "definition": Object {
+                    "base": Object {
+                      "max": "1",
+                      "min": 0,
+                      "path": "Coding.system",
+                    },
+                    "comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
+                    "constraint": Array [
+                      Object {
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "human": "All FHIR elements must have a @value or children",
+                        "key": "ele-1",
+                        "severity": "error",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                        "xpath": "@value|f:*|h:div",
+                      },
+                    ],
+                    "definition": "The identification of the code system that defines the meaning of the symbol in the code.",
+                    "fixedUri": "http://loinc.org",
+                    "id": "Observation.code.coding:HeartRateCode.system",
+                    "isModifier": false,
+                    "isSummary": true,
+                    "mapping": Array [
+                      Object {
+                        "identity": "v2",
+                        "map": "C*E.3",
+                      },
+                      Object {
+                        "identity": "rim",
+                        "map": "./codeSystem",
+                      },
+                      Object {
+                        "identity": "orim",
+                        "map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem",
+                      },
+                    ],
+                    "max": "1",
+                    "min": 1,
+                    "path": "Observation.code.coding.system",
+                    "requirements": "Need to be unambiguous about the source of the definition of the symbol.",
+                    "short": "Identity of the terminology system",
+                    "type": Array [
+                      Object {
+                        "code": "uri",
+                      },
+                    ],
+                  },
+                  "index": undefined,
+                  "isArray": false,
+                  "isPrimitive": true,
+                  "isRequired": true,
+                  "isSlice": false,
+                  "name": "system",
+                  "parent": undefined,
+                  "slices": Array [],
+                  "types": Array [
+                    "uri",
+                  ],
+                },
+                Object {
+                  "children": Array [],
+                  "definition": Object {
+                    "base": Object {
+                      "max": "1",
+                      "min": 0,
+                      "path": "Coding.version",
+                    },
+                    "comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
+                    "constraint": Array [
+                      Object {
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "human": "All FHIR elements must have a @value or children",
+                        "key": "ele-1",
+                        "severity": "error",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                        "xpath": "@value|f:*|h:div",
+                      },
+                    ],
+                    "definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
+                    "id": "Observation.code.coding:HeartRateCode.version",
+                    "isModifier": false,
+                    "isSummary": true,
+                    "mapping": Array [
+                      Object {
+                        "identity": "v2",
+                        "map": "C*E.7",
+                      },
+                      Object {
+                        "identity": "rim",
+                        "map": "./codeSystemVersion",
+                      },
+                      Object {
+                        "identity": "orim",
+                        "map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion",
+                      },
+                    ],
+                    "max": "1",
+                    "min": 0,
+                    "path": "Observation.code.coding.version",
+                    "short": "Version of the system - if relevant",
+                    "type": Array [
+                      Object {
+                        "code": "string",
+                      },
+                    ],
+                  },
+                  "index": undefined,
+                  "isArray": false,
+                  "isPrimitive": true,
+                  "isRequired": false,
+                  "isSlice": false,
+                  "name": "version",
+                  "parent": undefined,
+                  "slices": Array [],
+                  "types": Array [
+                    "string",
+                  ],
+                },
+                Object {
+                  "children": Array [],
+                  "definition": Object {
+                    "base": Object {
+                      "max": "1",
+                      "min": 0,
+                      "path": "Coding.code",
+                    },
+                    "constraint": Array [
+                      Object {
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "human": "All FHIR elements must have a @value or children",
+                        "key": "ele-1",
+                        "severity": "error",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                        "xpath": "@value|f:*|h:div",
+                      },
+                    ],
+                    "definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
+                    "fixedCode": "8867-4",
+                    "id": "Observation.code.coding:HeartRateCode.code",
+                    "isModifier": false,
+                    "isSummary": true,
+                    "mapping": Array [
+                      Object {
+                        "identity": "v2",
+                        "map": "C*E.1",
+                      },
+                      Object {
+                        "identity": "rim",
+                        "map": "./code",
+                      },
+                      Object {
+                        "identity": "orim",
+                        "map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code",
+                      },
+                    ],
+                    "max": "1",
+                    "min": 1,
+                    "path": "Observation.code.coding.code",
+                    "requirements": "Need to refer to a particular code in the system.",
+                    "short": "Symbol in syntax defined by the system",
+                    "type": Array [
+                      Object {
+                        "code": "code",
+                      },
+                    ],
+                  },
+                  "index": undefined,
+                  "isArray": false,
+                  "isPrimitive": true,
+                  "isRequired": true,
+                  "isSlice": false,
+                  "name": "code",
+                  "parent": undefined,
+                  "slices": Array [],
+                  "types": Array [
+                    "code",
+                  ],
+                },
+                Object {
+                  "children": Array [],
+                  "definition": Object {
+                    "base": Object {
+                      "max": "1",
+                      "min": 0,
+                      "path": "Coding.display",
+                    },
+                    "constraint": Array [
+                      Object {
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "human": "All FHIR elements must have a @value or children",
+                        "key": "ele-1",
+                        "severity": "error",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                        "xpath": "@value|f:*|h:div",
+                      },
+                    ],
+                    "definition": "A representation of the meaning of the code in the system, following the rules of the system.",
+                    "extension": Array [
+                      Object {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true,
+                      },
+                    ],
+                    "id": "Observation.code.coding:HeartRateCode.display",
+                    "isModifier": false,
+                    "isSummary": true,
+                    "mapping": Array [
+                      Object {
+                        "identity": "v2",
+                        "map": "C*E.2 - but note this is not well followed",
+                      },
+                      Object {
+                        "identity": "rim",
+                        "map": "CV.displayName",
+                      },
+                      Object {
+                        "identity": "orim",
+                        "map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName",
+                      },
+                    ],
+                    "max": "1",
+                    "min": 0,
+                    "path": "Observation.code.coding.display",
+                    "requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
+                    "short": "Representation defined by the system",
+                    "type": Array [
+                      Object {
+                        "code": "string",
+                      },
+                    ],
+                  },
+                  "index": undefined,
+                  "isArray": false,
+                  "isPrimitive": true,
+                  "isRequired": false,
+                  "isSlice": false,
+                  "name": "display",
+                  "parent": undefined,
+                  "slices": Array [],
+                  "types": Array [
+                    "string",
+                  ],
+                },
+                Object {
+                  "children": Array [],
+                  "definition": Object {
+                    "base": Object {
+                      "max": "1",
+                      "min": 0,
+                      "path": "Coding.userSelected",
+                    },
+                    "comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
+                    "constraint": Array [
+                      Object {
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "human": "All FHIR elements must have a @value or children",
+                        "key": "ele-1",
+                        "severity": "error",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                        "xpath": "@value|f:*|h:div",
+                      },
+                    ],
+                    "definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
+                    "id": "Observation.code.coding:HeartRateCode.userSelected",
+                    "isModifier": false,
+                    "isSummary": true,
+                    "mapping": Array [
+                      Object {
+                        "identity": "v2",
+                        "map": "Sometimes implied by being first",
+                      },
+                      Object {
+                        "identity": "rim",
+                        "map": "CD.codingRationale",
+                      },
+                      Object {
+                        "identity": "orim",
+                        "map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\\\#true a [     fhir:source \\"true\\";     fhir:target dt:CDCoding.codingRationale\\\\#O   ]",
+                      },
+                    ],
+                    "max": "1",
+                    "min": 0,
+                    "path": "Observation.code.coding.userSelected",
+                    "requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
+                    "short": "If this coding was chosen directly by the user",
+                    "type": Array [
+                      Object {
+                        "code": "boolean",
+                      },
+                    ],
+                  },
+                  "index": undefined,
+                  "isArray": false,
+                  "isPrimitive": true,
+                  "isRequired": false,
+                  "isSlice": false,
+                  "name": "userSelected",
+                  "parent": undefined,
+                  "slices": Array [],
+                  "types": Array [
+                    "boolean",
+                  ],
+                },
+              ],
+              "definition": Object {
+                "base": Object {
+                  "max": "*",
+                  "min": 0,
+                  "path": "CodeableConcept.coding",
+                },
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "constraint": Array [
+                  Object {
+                    "expression": "hasValue() or (children().count() > id.count())",
+                    "human": "All FHIR elements must have a @value or children",
+                    "key": "ele-1",
+                    "severity": "error",
+                    "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                    "xpath": "@value|f:*|h:div",
+                  },
+                ],
+                "definition": "A reference to a code defined by a terminology system.",
+                "id": "Observation.code.coding:HeartRateCode",
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": Array [
+                  Object {
+                    "identity": "v2",
+                    "map": "C*E.1-8, C*E.10-22",
+                  },
+                  Object {
+                    "identity": "rim",
+                    "map": "union(., ./translation)",
+                  },
+                  Object {
+                    "identity": "orim",
+                    "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding",
+                  },
+                ],
+                "max": "1",
+                "min": 1,
+                "path": "Observation.code.coding",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "short": "Code defined by a terminology system",
+                "sliceName": "HeartRateCode",
+                "type": Array [
+                  Object {
+                    "code": "Coding",
+                  },
+                ],
+              },
+              "index": undefined,
+              "isArray": false,
+              "isPrimitive": false,
+              "isRequired": true,
+              "isSlice": true,
+              "name": "coding:HeartRateCode",
+              "parent": undefined,
+              "slices": Array [],
+              "types": Array [
+                "Coding",
+              ],
+            },
+          ],
+          "types": Array [
+            "Coding",
+          ],
+        },
+        Object {
+          "children": Array [],
+          "definition": Object {
+            "base": Object {
+              "max": "1",
+              "min": 0,
+              "path": "CodeableConcept.text",
+            },
+            "comment": "Very often the text is the same as a displayName of one of the codings.",
+            "constraint": Array [
+              Object {
+                "expression": "hasValue() or (children().count() > id.count())",
+                "human": "All FHIR elements must have a @value or children",
+                "key": "ele-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                "xpath": "@value|f:*|h:div",
+              },
+            ],
+            "definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
+            "extension": Array [
+              Object {
+                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                "valueBoolean": true,
+              },
+            ],
+            "id": "Observation.code.text",
+            "isModifier": false,
+            "isSummary": true,
+            "mapping": Array [
+              Object {
+                "identity": "v2",
+                "map": "C*E.9. But note many systems use C*E.2 for this",
+              },
+              Object {
+                "identity": "rim",
+                "map": "./originalText[mediaType/code=\\"text/plain\\"]/data",
+              },
+              Object {
+                "identity": "orim",
+                "map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText",
+              },
+            ],
+            "max": "1",
+            "min": 0,
+            "path": "Observation.code.text",
+            "requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
+            "short": "Plain text representation of the concept",
+            "type": Array [
+              Object {
+                "code": "string",
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": false,
+          "isPrimitive": true,
+          "isRequired": false,
+          "isSlice": false,
+          "name": "text",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "string",
+          ],
+        },
+      ],
+      "definition": Object {
+        "alias": Array [
+          "Name",
+          "Test",
+        ],
+        "base": Object {
+          "max": "1",
+          "min": 1,
+          "path": "Observation.code",
+        },
+        "binding": Object {
+          "description": "This identifies the vital sign result type.",
+          "extension": Array [
+            Object {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+              "valueString": "VitalSigns",
+            },
+          ],
+          "strength": "extensible",
+          "valueSet": "http://hl7.org/fhir/ValueSet/observation-vitalsignresult",
+        },
+        "comment": "additional codes that translate or map to this code are allowed.  For example a more granular LOINC code or code that is used locally in a system.",
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "Heart Rate.",
+        "id": "Observation.code",
+        "isModifier": false,
+        "isSummary": true,
+        "mapping": Array [
+          Object {
+            "identity": "workflow",
+            "map": "Event.code",
+          },
+          Object {
+            "identity": "w5",
+            "map": "FiveWs.what[x]",
+          },
+          Object {
+            "identity": "sct-concept",
+            "map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|",
+          },
+          Object {
+            "identity": "v2",
+            "map": "OBX-3",
+          },
+          Object {
+            "identity": "rim",
+            "map": "code",
+          },
+          Object {
+            "identity": "sct-attr",
+            "map": "116680003 |Is a|",
+          },
+        ],
+        "max": "1",
+        "min": 1,
+        "mustSupport": true,
+        "path": "Observation.code",
+        "requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
+        "short": "Heart Rate",
+        "type": Array [
+          Object {
+            "code": "CodeableConcept",
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": false,
+      "isPrimitive": false,
+      "isRequired": true,
+      "isSlice": false,
+      "name": "code",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "CodeableConcept",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "base": Object {
+          "max": "1",
+          "min": 0,
+          "path": "Observation.subject",
+        },
+        "comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the \`focus\` element or the \`code\` itself specifies the actual focus of the observation.",
+        "id": "Observation.subject",
+        "isModifier": false,
+        "isSummary": true,
+        "mapping": Array [
+          Object {
+            "identity": "workflow",
+            "map": "Event.subject",
+          },
+          Object {
+            "identity": "w5",
+            "map": "FiveWs.subject[x]",
+          },
+          Object {
+            "identity": "v2",
+            "map": "PID-3",
+          },
+          Object {
+            "identity": "rim",
+            "map": "participation[typeCode=RTGT] ",
+          },
+          Object {
+            "identity": "w5",
+            "map": "FiveWs.subject",
+          },
+        ],
+        "max": "1",
+        "min": 1,
+        "mustSupport": true,
+        "path": "Observation.subject",
+        "requirements": "Observations have no value if you don't know who or what they're about.",
+        "short": "Who and/or what the observation is about",
+        "type": Array [
+          Object {
+            "code": "Reference",
+            "targetProfile": Array [
+              "http://hl7.org/fhir/StructureDefinition/Patient",
+            ],
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": false,
+      "isPrimitive": false,
+      "isRequired": true,
+      "isSlice": false,
+      "name": "subject",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "Reference",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "base": Object {
+          "max": "*",
+          "min": 0,
+          "path": "Observation.focus",
+        },
+        "comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \\"Blood Glucose\\") and does not need to be represented separately using this element.  Use \`specimen\` if a reference to a specimen is required.  If a code is required instead of a resource use either  \`bodysite\` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
+        "extension": Array [
+          Object {
+            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+            "valueCode": "trial-use",
+          },
+        ],
+        "id": "Observation.focus",
+        "isModifier": false,
+        "isSummary": true,
+        "mapping": Array [
+          Object {
+            "identity": "w5",
+            "map": "FiveWs.subject[x]",
+          },
+          Object {
+            "identity": "v2",
+            "map": "OBX-3",
+          },
+          Object {
+            "identity": "rim",
+            "map": "participation[typeCode=SBJ]",
+          },
+          Object {
+            "identity": "w5",
+            "map": "FiveWs.subject",
+          },
+        ],
+        "max": "*",
+        "min": 0,
+        "path": "Observation.focus",
+        "short": "What the observation is about, when it is not about the subject of record",
+        "type": Array [
+          Object {
+            "code": "Reference",
+            "targetProfile": Array [
+              "http://hl7.org/fhir/StructureDefinition/Resource",
+            ],
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": true,
+      "isPrimitive": false,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "focus",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "Reference",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "alias": Array [
+          "Context",
+        ],
+        "base": Object {
+          "max": "1",
+          "min": 0,
+          "path": "Observation.encounter",
+        },
+        "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
+        "id": "Observation.encounter",
+        "isModifier": false,
+        "isSummary": true,
+        "mapping": Array [
+          Object {
+            "identity": "workflow",
+            "map": "Event.context",
+          },
+          Object {
+            "identity": "w5",
+            "map": "FiveWs.context",
+          },
+          Object {
+            "identity": "v2",
+            "map": "PV1",
+          },
+          Object {
+            "identity": "rim",
+            "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]",
+          },
+        ],
+        "max": "1",
+        "min": 0,
+        "path": "Observation.encounter",
+        "requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
+        "short": "Healthcare event during which this observation is made",
+        "type": Array [
+          Object {
+            "code": "Reference",
+            "targetProfile": Array [
+              "http://hl7.org/fhir/StructureDefinition/Encounter",
+            ],
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": false,
+      "isPrimitive": false,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "encounter",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "Reference",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "alias": Array [
+          "Occurrence",
+        ],
+        "base": Object {
+          "max": "1",
+          "min": 0,
+          "path": "Observation.effective[x]",
+        },
+        "comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \\"fuzzy\\" times (For example, a blood glucose measurement taken \\"after breakfast\\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
+        "condition": Array [
+          "vs-1",
+        ],
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+          Object {
+            "expression": "($this as dateTime).toString().length() >= 8",
+            "human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
+            "key": "vs-1",
+            "severity": "error",
+            "xpath": "f:effectiveDateTime[matches(@value, '^\\\\d{4}-\\\\d{2}-\\\\d{2}')]",
+          },
+        ],
+        "definition": "Often just a dateTime for Vital Signs.",
+        "id": "Observation.effective[x]",
+        "isModifier": false,
+        "isSummary": true,
+        "mapping": Array [
+          Object {
+            "identity": "workflow",
+            "map": "Event.occurrence[x]",
+          },
+          Object {
+            "identity": "w5",
+            "map": "FiveWs.done[x]",
+          },
+          Object {
+            "identity": "v2",
+            "map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)",
+          },
+          Object {
+            "identity": "rim",
+            "map": "effectiveTime",
+          },
+        ],
+        "max": "1",
+        "min": 1,
+        "mustSupport": true,
+        "path": "Observation.effective[x]",
+        "requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
+        "short": "Often just a dateTime for Vital Signs",
+        "type": Array [
+          Object {
+            "code": "dateTime",
+          },
+          Object {
+            "code": "Period",
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": false,
+      "isPrimitive": false,
+      "isRequired": true,
+      "isSlice": false,
+      "name": "effective[x]",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "dateTime",
+        "Period",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "base": Object {
+          "max": "1",
+          "min": 0,
+          "path": "Observation.issued",
+        },
+        "comment": "For Observations that don’t require review and verification, it may be the same as the [\`lastUpdated\` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the \`lastUpdated\` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
+        "id": "Observation.issued",
+        "isModifier": false,
+        "isSummary": true,
+        "mapping": Array [
+          Object {
+            "identity": "w5",
+            "map": "FiveWs.recorded",
+          },
+          Object {
+            "identity": "v2",
+            "map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)",
+          },
+          Object {
+            "identity": "rim",
+            "map": "participation[typeCode=AUT].time",
+          },
+        ],
+        "max": "1",
+        "min": 0,
+        "path": "Observation.issued",
+        "short": "Date/Time this version was made available",
+        "type": Array [
+          Object {
+            "code": "instant",
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": false,
+      "isPrimitive": true,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "issued",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "instant",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "base": Object {
+          "max": "*",
+          "min": 0,
+          "path": "Observation.performer",
+        },
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "Who was responsible for asserting the observed value as \\"true\\".",
+        "id": "Observation.performer",
+        "isModifier": false,
+        "isSummary": true,
+        "mapping": Array [
+          Object {
+            "identity": "workflow",
+            "map": "Event.performer.actor",
+          },
+          Object {
+            "identity": "w5",
+            "map": "FiveWs.actor",
+          },
+          Object {
+            "identity": "v2",
+            "map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'",
+          },
+          Object {
+            "identity": "rim",
+            "map": "participation[typeCode=PRF]",
+          },
+        ],
+        "max": "*",
+        "min": 0,
+        "path": "Observation.performer",
+        "requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
+        "short": "Who is responsible for the observation",
+        "type": Array [
+          Object {
+            "code": "Reference",
+            "targetProfile": Array [
+              "http://hl7.org/fhir/StructureDefinition/Practitioner",
+              "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+              "http://hl7.org/fhir/StructureDefinition/Organization",
+              "http://hl7.org/fhir/StructureDefinition/CareTeam",
+              "http://hl7.org/fhir/StructureDefinition/Patient",
+              "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+            ],
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": true,
+      "isPrimitive": false,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "performer",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "Reference",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "base": Object {
+          "max": "1",
+          "min": 0,
+          "path": "Observation.value[x]",
+        },
+        "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+        "condition": Array [
+          "obs-7",
+          "vs-2",
+        ],
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
+        "id": "Observation.value[x]",
+        "isModifier": false,
+        "isSummary": true,
+        "mapping": Array [
+          Object {
+            "identity": "sct-concept",
+            "map": "< 441742003 |Evaluation finding|",
+          },
+          Object {
+            "identity": "v2",
+            "map": "OBX.2, OBX.5, OBX.6",
+          },
+          Object {
+            "identity": "rim",
+            "map": "value",
+          },
+          Object {
+            "identity": "sct-attr",
+            "map": "363714003 |Interprets|",
+          },
+        ],
+        "max": "1",
+        "min": 0,
+        "mustSupport": true,
+        "path": "Observation.value[x]",
+        "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\\"PQ\\" (CONF:7305).",
+        "short": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
+        "slicing": Object {
+          "discriminator": Array [
+            Object {
+              "path": "$this",
+              "type": "type",
+            },
+          ],
+          "ordered": false,
+          "rules": "closed",
+        },
+        "type": Array [
+          Object {
+            "code": "Quantity",
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": false,
+      "isPrimitive": false,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "value[x]",
+      "parent": undefined,
+      "slices": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "definition": Object {
+                "base": Object {
+                  "max": "1",
+                  "min": 0,
+                  "path": "Element.id",
+                },
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "id": "Observation.value[x]:valueQuantity.id",
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": Array [
+                  Object {
+                    "identity": "rim",
+                    "map": "n/a",
+                  },
+                ],
+                "max": "1",
+                "min": 0,
+                "path": "Observation.value[x].id",
+                "representation": Array [
+                  "xmlAttr",
+                ],
+                "short": "Unique id for inter-element referencing",
+                "type": Array [
+                  Object {
+                    "code": "http://hl7.org/fhirpath/System.String",
+                    "extension": Array [
+                      Object {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                        "valueUrl": "string",
+                      },
+                    ],
+                  },
+                ],
+              },
+              "index": undefined,
+              "isArray": false,
+              "isPrimitive": false,
+              "isRequired": false,
+              "isSlice": false,
+              "name": "id",
+              "parent": undefined,
+              "slices": Array [],
+              "types": Array [
+                "http://hl7.org/fhirpath/System.String",
+              ],
+            },
+            Object {
+              "children": Array [],
+              "definition": Object {
+                "alias": Array [
+                  "extensions",
+                  "user content",
+                ],
+                "base": Object {
+                  "max": "*",
+                  "min": 0,
+                  "path": "Element.extension",
+                },
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "constraint": Array [
+                  Object {
+                    "expression": "hasValue() or (children().count() > id.count())",
+                    "human": "All FHIR elements must have a @value or children",
+                    "key": "ele-1",
+                    "severity": "error",
+                    "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                    "xpath": "@value|f:*|h:div",
+                  },
+                  Object {
+                    "expression": "extension.exists() != value.exists()",
+                    "human": "Must have either extensions or value[x], not both",
+                    "key": "ext-1",
+                    "severity": "error",
+                    "source": "http://hl7.org/fhir/StructureDefinition/Extension",
+                    "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \\"value\\")])",
+                  },
+                ],
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "id": "Observation.value[x]:valueQuantity.extension",
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": Array [
+                  Object {
+                    "identity": "rim",
+                    "map": "n/a",
+                  },
+                ],
+                "max": "*",
+                "min": 0,
+                "path": "Observation.value[x].extension",
+                "short": "Additional content defined by implementations",
+                "slicing": Object {
+                  "description": "Extensions are always sliced by (at least) url",
+                  "discriminator": Array [
+                    Object {
+                      "path": "url",
+                      "type": "value",
+                    },
+                  ],
+                  "rules": "open",
+                },
+                "type": Array [
+                  Object {
+                    "code": "Extension",
+                  },
+                ],
+              },
+              "index": undefined,
+              "isArray": true,
+              "isPrimitive": false,
+              "isRequired": false,
+              "isSlice": false,
+              "name": "extension",
+              "parent": undefined,
+              "slices": Array [],
+              "types": Array [
+                "Extension",
+              ],
+            },
+            Object {
+              "children": Array [],
+              "definition": Object {
+                "base": Object {
+                  "max": "1",
+                  "min": 0,
+                  "path": "Quantity.value",
+                },
+                "comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
+                "constraint": Array [
+                  Object {
+                    "expression": "hasValue() or (children().count() > id.count())",
+                    "human": "All FHIR elements must have a @value or children",
+                    "key": "ele-1",
+                    "severity": "error",
+                    "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                    "xpath": "@value|f:*|h:div",
+                  },
+                ],
+                "definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
+                "id": "Observation.value[x]:valueQuantity.value",
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": Array [
+                  Object {
+                    "identity": "v2",
+                    "map": "SN.2  / CQ - N/A",
+                  },
+                  Object {
+                    "identity": "rim",
+                    "map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value",
+                  },
+                ],
+                "max": "1",
+                "min": 1,
+                "mustSupport": true,
+                "path": "Observation.value[x].value",
+                "requirements": "Precision is handled implicitly in almost all cases of measurement.",
+                "short": "Numerical value (with implicit precision)",
+                "type": Array [
+                  Object {
+                    "code": "decimal",
+                  },
+                ],
+              },
+              "index": undefined,
+              "isArray": false,
+              "isPrimitive": true,
+              "isRequired": true,
+              "isSlice": false,
+              "name": "value",
+              "parent": undefined,
+              "slices": Array [],
+              "types": Array [
+                "decimal",
+              ],
+            },
+            Object {
+              "children": Array [],
+              "definition": Object {
+                "base": Object {
+                  "max": "1",
+                  "min": 0,
+                  "path": "Quantity.comparator",
+                },
+                "binding": Object {
+                  "description": "How the Quantity should be understood and represented.",
+                  "extension": Array [
+                    Object {
+                      "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                      "valueString": "QuantityComparator",
+                    },
+                  ],
+                  "strength": "required",
+                  "valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1",
+                },
+                "constraint": Array [
+                  Object {
+                    "expression": "hasValue() or (children().count() > id.count())",
+                    "human": "All FHIR elements must have a @value or children",
+                    "key": "ele-1",
+                    "severity": "error",
+                    "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                    "xpath": "@value|f:*|h:div",
+                  },
+                ],
+                "definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \\"<\\" , then the real value is < stated value.",
+                "id": "Observation.value[x]:valueQuantity.comparator",
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \\"Is Modifier\\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
+                "isSummary": true,
+                "mapping": Array [
+                  Object {
+                    "identity": "v2",
+                    "map": "SN.1  / CQ.1",
+                  },
+                  Object {
+                    "identity": "rim",
+                    "map": "IVL properties",
+                  },
+                ],
+                "max": "1",
+                "meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
+                "min": 0,
+                "path": "Observation.value[x].comparator",
+                "requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
+                "short": "< | <= | >= | > - how to understand the value",
+                "type": Array [
+                  Object {
+                    "code": "code",
+                  },
+                ],
+              },
+              "index": undefined,
+              "isArray": false,
+              "isPrimitive": true,
+              "isRequired": false,
+              "isSlice": false,
+              "name": "comparator",
+              "parent": undefined,
+              "slices": Array [],
+              "types": Array [
+                "code",
+              ],
+            },
+            Object {
+              "children": Array [],
+              "definition": Object {
+                "base": Object {
+                  "max": "1",
+                  "min": 0,
+                  "path": "Quantity.unit",
+                },
+                "constraint": Array [
+                  Object {
+                    "expression": "hasValue() or (children().count() > id.count())",
+                    "human": "All FHIR elements must have a @value or children",
+                    "key": "ele-1",
+                    "severity": "error",
+                    "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                    "xpath": "@value|f:*|h:div",
+                  },
+                ],
+                "definition": "A human-readable form of the unit.",
+                "extension": Array [
+                  Object {
+                    "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                    "valueBoolean": true,
+                  },
+                ],
+                "id": "Observation.value[x]:valueQuantity.unit",
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": Array [
+                  Object {
+                    "identity": "v2",
+                    "map": "(see OBX.6 etc.) / CQ.2",
+                  },
+                  Object {
+                    "identity": "rim",
+                    "map": "PQ.unit",
+                  },
+                ],
+                "max": "1",
+                "min": 1,
+                "mustSupport": true,
+                "path": "Observation.value[x].unit",
+                "requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
+                "short": "Unit representation",
+                "type": Array [
+                  Object {
+                    "code": "string",
+                  },
+                ],
+              },
+              "index": undefined,
+              "isArray": false,
+              "isPrimitive": true,
+              "isRequired": true,
+              "isSlice": false,
+              "name": "unit",
+              "parent": undefined,
+              "slices": Array [],
+              "types": Array [
+                "string",
+              ],
+            },
+            Object {
+              "children": Array [],
+              "definition": Object {
+                "base": Object {
+                  "max": "1",
+                  "min": 0,
+                  "path": "Quantity.system",
+                },
+                "condition": Array [
+                  "qty-3",
+                ],
+                "constraint": Array [
+                  Object {
+                    "expression": "hasValue() or (children().count() > id.count())",
+                    "human": "All FHIR elements must have a @value or children",
+                    "key": "ele-1",
+                    "severity": "error",
+                    "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                    "xpath": "@value|f:*|h:div",
+                  },
+                ],
+                "definition": "The identification of the system that provides the coded form of the unit.",
+                "fixedUri": "http://unitsofmeasure.org",
+                "id": "Observation.value[x]:valueQuantity.system",
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": Array [
+                  Object {
+                    "identity": "v2",
+                    "map": "(see OBX.6 etc.) / CQ.2",
+                  },
+                  Object {
+                    "identity": "rim",
+                    "map": "CO.codeSystem, PQ.translation.codeSystem",
+                  },
+                ],
+                "max": "1",
+                "min": 1,
+                "mustSupport": true,
+                "path": "Observation.value[x].system",
+                "requirements": "Need to know the system that defines the coded form of the unit.",
+                "short": "System that defines coded unit form",
+                "type": Array [
+                  Object {
+                    "code": "uri",
+                  },
+                ],
+              },
+              "index": undefined,
+              "isArray": false,
+              "isPrimitive": true,
+              "isRequired": true,
+              "isSlice": false,
+              "name": "system",
+              "parent": undefined,
+              "slices": Array [],
+              "types": Array [
+                "uri",
+              ],
+            },
+            Object {
+              "children": Array [],
+              "definition": Object {
+                "base": Object {
+                  "max": "1",
+                  "min": 0,
+                  "path": "Quantity.code",
+                },
+                "comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
+                "constraint": Array [
+                  Object {
+                    "expression": "hasValue() or (children().count() > id.count())",
+                    "human": "All FHIR elements must have a @value or children",
+                    "key": "ele-1",
+                    "severity": "error",
+                    "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                    "xpath": "@value|f:*|h:div",
+                  },
+                ],
+                "definition": "Coded responses from the common UCUM units for vital signs value set.",
+                "fixedCode": "/min",
+                "id": "Observation.value[x]:valueQuantity.code",
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": Array [
+                  Object {
+                    "identity": "v2",
+                    "map": "(see OBX.6 etc.) / CQ.2",
+                  },
+                  Object {
+                    "identity": "rim",
+                    "map": "PQ.code, MO.currency, PQ.translation.code",
+                  },
+                ],
+                "max": "1",
+                "min": 1,
+                "mustSupport": true,
+                "path": "Observation.value[x].code",
+                "requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "type": Array [
+                  Object {
+                    "code": "code",
+                  },
+                ],
+              },
+              "index": undefined,
+              "isArray": false,
+              "isPrimitive": true,
+              "isRequired": true,
+              "isSlice": false,
+              "name": "code",
+              "parent": undefined,
+              "slices": Array [],
+              "types": Array [
+                "code",
+              ],
+            },
+          ],
+          "definition": Object {
+            "base": Object {
+              "max": "1",
+              "min": 0,
+              "path": "Observation.value[x]",
+            },
+            "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+            "condition": Array [
+              "obs-7",
+              "vs-2",
+            ],
+            "constraint": Array [
+              Object {
+                "expression": "hasValue() or (children().count() > id.count())",
+                "human": "All FHIR elements must have a @value or children",
+                "key": "ele-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                "xpath": "@value|f:*|h:div",
+              },
+            ],
+            "definition": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
+            "id": "Observation.value[x]:valueQuantity",
+            "isModifier": false,
+            "isSummary": true,
+            "mapping": Array [
+              Object {
+                "identity": "sct-concept",
+                "map": "< 441742003 |Evaluation finding|",
+              },
+              Object {
+                "identity": "v2",
+                "map": "OBX.2, OBX.5, OBX.6",
+              },
+              Object {
+                "identity": "rim",
+                "map": "value",
+              },
+              Object {
+                "identity": "sct-attr",
+                "map": "363714003 |Interprets|",
+              },
+            ],
+            "max": "1",
+            "min": 0,
+            "mustSupport": true,
+            "path": "Observation.value[x]",
+            "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\\"PQ\\" (CONF:7305).",
+            "short": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
+            "sliceName": "valueQuantity",
+            "type": Array [
+              Object {
+                "code": "Quantity",
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": false,
+          "isPrimitive": false,
+          "isRequired": false,
+          "isSlice": true,
+          "name": "value[x]:valueQuantity",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "Quantity",
+          ],
+        },
+      ],
+      "types": Array [
+        "Quantity",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "base": Object {
+          "max": "1",
+          "min": 0,
+          "path": "Observation.dataAbsentReason",
+        },
+        "binding": Object {
+          "description": "Codes specifying why the result (\`Observation.value[x]\`) is missing.",
+          "extension": Array [
+            Object {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+              "valueString": "ObservationValueAbsentReason",
+            },
+          ],
+          "strength": "extensible",
+          "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason",
+        },
+        "comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \\"detected\\", \\"not detected\\", \\"inconclusive\\", or  \\"specimen unsatisfactory\\".   
+
+The alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \\"error\\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
+        "condition": Array [
+          "obs-6",
+          "vs-2",
+        ],
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
+        "id": "Observation.dataAbsentReason",
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": Array [
+          Object {
+            "identity": "v2",
+            "map": "N/A",
+          },
+          Object {
+            "identity": "rim",
+            "map": "value.nullFlavor",
+          },
+        ],
+        "max": "1",
+        "min": 0,
+        "mustSupport": true,
+        "path": "Observation.dataAbsentReason",
+        "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+        "short": "Why the result is missing",
+        "type": Array [
+          Object {
+            "code": "CodeableConcept",
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": false,
+      "isPrimitive": false,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "dataAbsentReason",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "CodeableConcept",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "alias": Array [
+          "Abnormal Flag",
+        ],
+        "base": Object {
+          "max": "*",
+          "min": 0,
+          "path": "Observation.interpretation",
+        },
+        "binding": Object {
+          "description": "Codes identifying interpretations of observations.",
+          "extension": Array [
+            Object {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+              "valueString": "ObservationInterpretation",
+            },
+          ],
+          "strength": "extensible",
+          "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation",
+        },
+        "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+        "id": "Observation.interpretation",
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": Array [
+          Object {
+            "identity": "sct-concept",
+            "map": "< 260245000 |Findings values|",
+          },
+          Object {
+            "identity": "v2",
+            "map": "OBX-8",
+          },
+          Object {
+            "identity": "rim",
+            "map": "interpretationCode",
+          },
+          Object {
+            "identity": "sct-attr",
+            "map": "363713009 |Has interpretation|",
+          },
+        ],
+        "max": "*",
+        "min": 0,
+        "path": "Observation.interpretation",
+        "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+        "short": "High, low, normal, etc.",
+        "type": Array [
+          Object {
+            "code": "CodeableConcept",
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": true,
+      "isPrimitive": false,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "interpretation",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "CodeableConcept",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "base": Object {
+          "max": "*",
+          "min": 0,
+          "path": "Observation.note",
+        },
+        "comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "Comments about the observation or the results.",
+        "id": "Observation.note",
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": Array [
+          Object {
+            "identity": "v2",
+            "map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)",
+          },
+          Object {
+            "identity": "rim",
+            "map": "subjectOf.observationEvent[code=\\"annotation\\"].value",
+          },
+        ],
+        "max": "*",
+        "min": 0,
+        "path": "Observation.note",
+        "requirements": "Need to be able to provide free text additional information.",
+        "short": "Comments about the observation",
+        "type": Array [
+          Object {
+            "code": "Annotation",
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": true,
+      "isPrimitive": false,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "note",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "Annotation",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "base": Object {
+          "max": "1",
+          "min": 0,
+          "path": "Observation.bodySite",
+        },
+        "binding": Object {
+          "description": "Codes describing anatomical locations. May include laterality.",
+          "extension": Array [
+            Object {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+              "valueString": "BodySite",
+            },
+          ],
+          "strength": "example",
+          "valueSet": "http://hl7.org/fhir/ValueSet/body-site",
+        },
+        "comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   
+
+If the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+        "id": "Observation.bodySite",
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": Array [
+          Object {
+            "identity": "sct-concept",
+            "map": "< 123037004 |Body structure|",
+          },
+          Object {
+            "identity": "v2",
+            "map": "OBX-20",
+          },
+          Object {
+            "identity": "rim",
+            "map": "targetSiteCode",
+          },
+          Object {
+            "identity": "sct-attr",
+            "map": "718497002 |Inherent location|",
+          },
+        ],
+        "max": "1",
+        "min": 0,
+        "path": "Observation.bodySite",
+        "short": "Observed body part",
+        "type": Array [
+          Object {
+            "code": "CodeableConcept",
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": false,
+      "isPrimitive": false,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "bodySite",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "CodeableConcept",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "base": Object {
+          "max": "1",
+          "min": 0,
+          "path": "Observation.method",
+        },
+        "binding": Object {
+          "description": "Methods for simple observations.",
+          "extension": Array [
+            Object {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+              "valueString": "ObservationMethod",
+            },
+          ],
+          "strength": "example",
+          "valueSet": "http://hl7.org/fhir/ValueSet/observation-methods",
+        },
+        "comment": "Only used if not implicit in code for Observation.code.",
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "Indicates the mechanism used to perform the observation.",
+        "id": "Observation.method",
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": Array [
+          Object {
+            "identity": "v2",
+            "map": "OBX-17",
+          },
+          Object {
+            "identity": "rim",
+            "map": "methodCode",
+          },
+        ],
+        "max": "1",
+        "min": 0,
+        "path": "Observation.method",
+        "requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
+        "short": "How it was done",
+        "type": Array [
+          Object {
+            "code": "CodeableConcept",
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": false,
+      "isPrimitive": false,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "method",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "CodeableConcept",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "base": Object {
+          "max": "1",
+          "min": 0,
+          "path": "Observation.specimen",
+        },
+        "comment": "Should only be used if not implicit in code found in \`Observation.code\`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "The specimen that was used when this observation was made.",
+        "id": "Observation.specimen",
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": Array [
+          Object {
+            "identity": "sct-concept",
+            "map": "< 123038009 |Specimen|",
+          },
+          Object {
+            "identity": "v2",
+            "map": "SPM segment",
+          },
+          Object {
+            "identity": "rim",
+            "map": "participation[typeCode=SPC].specimen",
+          },
+          Object {
+            "identity": "sct-attr",
+            "map": "704319004 |Inherent in|",
+          },
+        ],
+        "max": "1",
+        "min": 0,
+        "path": "Observation.specimen",
+        "short": "Specimen used for this observation",
+        "type": Array [
+          Object {
+            "code": "Reference",
+            "targetProfile": Array [
+              "http://hl7.org/fhir/StructureDefinition/Specimen",
+            ],
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": false,
+      "isPrimitive": false,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "specimen",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "Reference",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "base": Object {
+          "max": "1",
+          "min": 0,
+          "path": "Observation.device",
+        },
+        "comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "The device used to generate the observation data.",
+        "id": "Observation.device",
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": Array [
+          Object {
+            "identity": "sct-concept",
+            "map": "< 49062001 |Device|",
+          },
+          Object {
+            "identity": "v2",
+            "map": "OBX-17 / PRT -10",
+          },
+          Object {
+            "identity": "rim",
+            "map": "participation[typeCode=DEV]",
+          },
+          Object {
+            "identity": "sct-attr",
+            "map": "424226004 |Using device|",
+          },
+        ],
+        "max": "1",
+        "min": 0,
+        "path": "Observation.device",
+        "short": "(Measurement) Device",
+        "type": Array [
+          Object {
+            "code": "Reference",
+            "targetProfile": Array [
+              "http://hl7.org/fhir/StructureDefinition/Device",
+              "http://hl7.org/fhir/StructureDefinition/DeviceMetric",
+            ],
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": false,
+      "isPrimitive": false,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "device",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "Reference",
+      ],
+    },
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "definition": Object {
+            "base": Object {
+              "max": "1",
+              "min": 0,
+              "path": "Element.id",
+            },
+            "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+            "id": "Observation.referenceRange.id",
+            "isModifier": false,
+            "isSummary": false,
+            "mapping": Array [
+              Object {
+                "identity": "rim",
+                "map": "n/a",
+              },
+            ],
+            "max": "1",
+            "min": 0,
+            "path": "Observation.referenceRange.id",
+            "representation": Array [
+              "xmlAttr",
+            ],
+            "short": "Unique id for inter-element referencing",
+            "type": Array [
+              Object {
+                "code": "http://hl7.org/fhirpath/System.String",
+                "extension": Array [
+                  Object {
+                    "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                    "valueUrl": "string",
+                  },
+                ],
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": false,
+          "isPrimitive": false,
+          "isRequired": false,
+          "isSlice": false,
+          "name": "id",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "http://hl7.org/fhirpath/System.String",
+          ],
+        },
+        Object {
+          "children": Array [],
+          "definition": Object {
+            "alias": Array [
+              "extensions",
+              "user content",
+            ],
+            "base": Object {
+              "max": "*",
+              "min": 0,
+              "path": "Element.extension",
+            },
+            "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+            "constraint": Array [
+              Object {
+                "expression": "hasValue() or (children().count() > id.count())",
+                "human": "All FHIR elements must have a @value or children",
+                "key": "ele-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                "xpath": "@value|f:*|h:div",
+              },
+              Object {
+                "expression": "extension.exists() != value.exists()",
+                "human": "Must have either extensions or value[x], not both",
+                "key": "ext-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Extension",
+                "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \\"value\\")])",
+              },
+            ],
+            "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+            "id": "Observation.referenceRange.extension",
+            "isModifier": false,
+            "isSummary": false,
+            "mapping": Array [
+              Object {
+                "identity": "rim",
+                "map": "n/a",
+              },
+            ],
+            "max": "*",
+            "min": 0,
+            "path": "Observation.referenceRange.extension",
+            "short": "Additional content defined by implementations",
+            "type": Array [
+              Object {
+                "code": "Extension",
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": true,
+          "isPrimitive": false,
+          "isRequired": false,
+          "isSlice": false,
+          "name": "extension",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "Extension",
+          ],
+        },
+        Object {
+          "children": Array [],
+          "definition": Object {
+            "alias": Array [
+              "extensions",
+              "user content",
+              "modifiers",
+            ],
+            "base": Object {
+              "max": "*",
+              "min": 0,
+              "path": "BackboneElement.modifierExtension",
+            },
+            "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+            "constraint": Array [
+              Object {
+                "expression": "hasValue() or (children().count() > id.count())",
+                "human": "All FHIR elements must have a @value or children",
+                "key": "ele-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                "xpath": "@value|f:*|h:div",
+              },
+              Object {
+                "expression": "extension.exists() != value.exists()",
+                "human": "Must have either extensions or value[x], not both",
+                "key": "ext-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Extension",
+                "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \\"value\\")])",
+              },
+            ],
+            "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.
+
+Modifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+            "id": "Observation.referenceRange.modifierExtension",
+            "isModifier": true,
+            "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+            "isSummary": true,
+            "mapping": Array [
+              Object {
+                "identity": "rim",
+                "map": "N/A",
+              },
+            ],
+            "max": "*",
+            "min": 0,
+            "path": "Observation.referenceRange.modifierExtension",
+            "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+            "short": "Extensions that cannot be ignored even if unrecognized",
+            "type": Array [
+              Object {
+                "code": "Extension",
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": true,
+          "isPrimitive": false,
+          "isRequired": false,
+          "isSlice": false,
+          "name": "modifierExtension",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "Extension",
+          ],
+        },
+        Object {
+          "children": Array [],
+          "definition": Object {
+            "base": Object {
+              "max": "1",
+              "min": 0,
+              "path": "Observation.referenceRange.low",
+            },
+            "condition": Array [
+              "obs-3",
+            ],
+            "constraint": Array [
+              Object {
+                "expression": "hasValue() or (children().count() > id.count())",
+                "human": "All FHIR elements must have a @value or children",
+                "key": "ele-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                "xpath": "@value|f:*|h:div",
+              },
+            ],
+            "definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
+            "id": "Observation.referenceRange.low",
+            "isModifier": false,
+            "isSummary": false,
+            "mapping": Array [
+              Object {
+                "identity": "v2",
+                "map": "OBX-7",
+              },
+              Object {
+                "identity": "rim",
+                "map": "value:IVL_PQ.low",
+              },
+            ],
+            "max": "1",
+            "min": 0,
+            "path": "Observation.referenceRange.low",
+            "short": "Low Range, if relevant",
+            "type": Array [
+              Object {
+                "code": "Quantity",
+                "profile": Array [
+                  "http://hl7.org/fhir/StructureDefinition/SimpleQuantity",
+                ],
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": false,
+          "isPrimitive": false,
+          "isRequired": false,
+          "isSlice": false,
+          "name": "low",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "Quantity",
+          ],
+        },
+        Object {
+          "children": Array [],
+          "definition": Object {
+            "base": Object {
+              "max": "1",
+              "min": 0,
+              "path": "Observation.referenceRange.high",
+            },
+            "condition": Array [
+              "obs-3",
+            ],
+            "constraint": Array [
+              Object {
+                "expression": "hasValue() or (children().count() > id.count())",
+                "human": "All FHIR elements must have a @value or children",
+                "key": "ele-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                "xpath": "@value|f:*|h:div",
+              },
+            ],
+            "definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
+            "id": "Observation.referenceRange.high",
+            "isModifier": false,
+            "isSummary": false,
+            "mapping": Array [
+              Object {
+                "identity": "v2",
+                "map": "OBX-7",
+              },
+              Object {
+                "identity": "rim",
+                "map": "value:IVL_PQ.high",
+              },
+            ],
+            "max": "1",
+            "min": 0,
+            "path": "Observation.referenceRange.high",
+            "short": "High Range, if relevant",
+            "type": Array [
+              Object {
+                "code": "Quantity",
+                "profile": Array [
+                  "http://hl7.org/fhir/StructureDefinition/SimpleQuantity",
+                ],
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": false,
+          "isPrimitive": false,
+          "isRequired": false,
+          "isSlice": false,
+          "name": "high",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "Quantity",
+          ],
+        },
+        Object {
+          "children": Array [],
+          "definition": Object {
+            "base": Object {
+              "max": "1",
+              "min": 0,
+              "path": "Observation.referenceRange.type",
+            },
+            "binding": Object {
+              "description": "Code for the meaning of a reference range.",
+              "extension": Array [
+                Object {
+                  "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                  "valueString": "ObservationRangeMeaning",
+                },
+              ],
+              "strength": "preferred",
+              "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning",
+            },
+            "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
+            "constraint": Array [
+              Object {
+                "expression": "hasValue() or (children().count() > id.count())",
+                "human": "All FHIR elements must have a @value or children",
+                "key": "ele-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                "xpath": "@value|f:*|h:div",
+              },
+            ],
+            "definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
+            "id": "Observation.referenceRange.type",
+            "isModifier": false,
+            "isSummary": false,
+            "mapping": Array [
+              Object {
+                "identity": "sct-concept",
+                "map": "< 260245000 |Findings values| OR  
+< 365860008 |General clinical state finding| 
+OR 
+< 250171008 |Clinical history or observation findings| OR  
+< 415229000 |Racial group| OR 
+< 365400002 |Finding of puberty stage| OR
+< 443938003 |Procedure carried out on subject|",
+              },
+              Object {
+                "identity": "v2",
+                "map": "OBX-10",
+              },
+              Object {
+                "identity": "rim",
+                "map": "interpretationCode",
+              },
+            ],
+            "max": "1",
+            "min": 0,
+            "path": "Observation.referenceRange.type",
+            "requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
+            "short": "Reference range qualifier",
+            "type": Array [
+              Object {
+                "code": "CodeableConcept",
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": false,
+          "isPrimitive": false,
+          "isRequired": false,
+          "isSlice": false,
+          "name": "type",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "CodeableConcept",
+          ],
+        },
+        Object {
+          "children": Array [],
+          "definition": Object {
+            "base": Object {
+              "max": "*",
+              "min": 0,
+              "path": "Observation.referenceRange.appliesTo",
+            },
+            "binding": Object {
+              "description": "Codes identifying the population the reference range applies to.",
+              "extension": Array [
+                Object {
+                  "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                  "valueString": "ObservationRangeType",
+                },
+              ],
+              "strength": "example",
+              "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto",
+            },
+            "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
+            "constraint": Array [
+              Object {
+                "expression": "hasValue() or (children().count() > id.count())",
+                "human": "All FHIR elements must have a @value or children",
+                "key": "ele-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                "xpath": "@value|f:*|h:div",
+              },
+            ],
+            "definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple \`appliesTo\`  are interpreted as an \\"AND\\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
+            "id": "Observation.referenceRange.appliesTo",
+            "isModifier": false,
+            "isSummary": false,
+            "mapping": Array [
+              Object {
+                "identity": "sct-concept",
+                "map": "< 260245000 |Findings values| OR  
+< 365860008 |General clinical state finding| 
+OR 
+< 250171008 |Clinical history or observation findings| OR  
+< 415229000 |Racial group| OR 
+< 365400002 |Finding of puberty stage| OR
+< 443938003 |Procedure carried out on subject|",
+              },
+              Object {
+                "identity": "v2",
+                "map": "OBX-10",
+              },
+              Object {
+                "identity": "rim",
+                "map": "interpretationCode",
+              },
+            ],
+            "max": "*",
+            "min": 0,
+            "path": "Observation.referenceRange.appliesTo",
+            "requirements": "Need to be able to identify the target population for proper interpretation.",
+            "short": "Reference range population",
+            "type": Array [
+              Object {
+                "code": "CodeableConcept",
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": true,
+          "isPrimitive": false,
+          "isRequired": false,
+          "isSlice": false,
+          "name": "appliesTo",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "CodeableConcept",
+          ],
+        },
+        Object {
+          "children": Array [],
+          "definition": Object {
+            "base": Object {
+              "max": "1",
+              "min": 0,
+              "path": "Observation.referenceRange.age",
+            },
+            "constraint": Array [
+              Object {
+                "expression": "hasValue() or (children().count() > id.count())",
+                "human": "All FHIR elements must have a @value or children",
+                "key": "ele-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                "xpath": "@value|f:*|h:div",
+              },
+            ],
+            "definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
+            "id": "Observation.referenceRange.age",
+            "isModifier": false,
+            "isSummary": false,
+            "mapping": Array [
+              Object {
+                "identity": "rim",
+                "map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\\"age\\"].value",
+              },
+            ],
+            "max": "1",
+            "min": 0,
+            "path": "Observation.referenceRange.age",
+            "requirements": "Some analytes vary greatly over age.",
+            "short": "Applicable age range, if relevant",
+            "type": Array [
+              Object {
+                "code": "Range",
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": false,
+          "isPrimitive": false,
+          "isRequired": false,
+          "isSlice": false,
+          "name": "age",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "Range",
+          ],
+        },
+        Object {
+          "children": Array [],
+          "definition": Object {
+            "base": Object {
+              "max": "1",
+              "min": 0,
+              "path": "Observation.referenceRange.text",
+            },
+            "constraint": Array [
+              Object {
+                "expression": "hasValue() or (children().count() > id.count())",
+                "human": "All FHIR elements must have a @value or children",
+                "key": "ele-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                "xpath": "@value|f:*|h:div",
+              },
+            ],
+            "definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \\"Negative\\" or a list or table of \\"normals\\".",
+            "id": "Observation.referenceRange.text",
+            "isModifier": false,
+            "isSummary": false,
+            "mapping": Array [
+              Object {
+                "identity": "v2",
+                "map": "OBX-7",
+              },
+              Object {
+                "identity": "rim",
+                "map": "value:ST",
+              },
+            ],
+            "max": "1",
+            "min": 0,
+            "path": "Observation.referenceRange.text",
+            "short": "Text based reference range in an observation",
+            "type": Array [
+              Object {
+                "code": "string",
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": false,
+          "isPrimitive": true,
+          "isRequired": false,
+          "isSlice": false,
+          "name": "text",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "string",
+          ],
+        },
+      ],
+      "definition": Object {
+        "base": Object {
+          "max": "*",
+          "min": 0,
+          "path": "Observation.referenceRange",
+        },
+        "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+          Object {
+            "expression": "low.exists() or high.exists() or text.exists()",
+            "human": "Must have at least a low or a high or text",
+            "key": "obs-3",
+            "severity": "error",
+            "xpath": "(exists(f:low) or exists(f:high)or exists(f:text))",
+          },
+        ],
+        "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \\"OR\\".   In other words, to represent two distinct target populations, two \`referenceRange\` elements would be used.",
+        "id": "Observation.referenceRange",
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": Array [
+          Object {
+            "identity": "v2",
+            "map": "OBX.7",
+          },
+          Object {
+            "identity": "rim",
+            "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]",
+          },
+        ],
+        "max": "*",
+        "min": 0,
+        "path": "Observation.referenceRange",
+        "requirements": "Knowing what values are considered \\"normal\\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+        "short": "Provides guide for interpretation",
+        "type": Array [
+          Object {
+            "code": "BackboneElement",
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": true,
+      "isPrimitive": false,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "referenceRange",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "BackboneElement",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "base": Object {
+          "max": "*",
+          "min": 0,
+          "path": "Observation.hasMember",
+        },
+        "comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "Used when reporting vital signs panel components.",
+        "id": "Observation.hasMember",
+        "isModifier": false,
+        "isSummary": true,
+        "mapping": Array [
+          Object {
+            "identity": "v2",
+            "map": "Relationships established by OBX-4 usage",
+          },
+          Object {
+            "identity": "rim",
+            "map": "outBoundRelationship",
+          },
+        ],
+        "max": "*",
+        "min": 0,
+        "path": "Observation.hasMember",
+        "short": "Used when reporting vital signs panel components",
+        "type": Array [
+          Object {
+            "code": "Reference",
+            "targetProfile": Array [
+              "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+              "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+              "http://hl7.org/fhir/StructureDefinition/vitalsigns",
+            ],
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": true,
+      "isPrimitive": false,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "hasMember",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "Reference",
+      ],
+    },
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "base": Object {
+          "max": "*",
+          "min": 0,
+          "path": "Observation.derivedFrom",
+        },
+        "comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+        ],
+        "definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
+        "id": "Observation.derivedFrom",
+        "isModifier": false,
+        "isSummary": true,
+        "mapping": Array [
+          Object {
+            "identity": "v2",
+            "map": "Relationships established by OBX-4 usage",
+          },
+          Object {
+            "identity": "rim",
+            "map": ".targetObservation",
+          },
+        ],
+        "max": "*",
+        "min": 0,
+        "path": "Observation.derivedFrom",
+        "short": "Related measurements the observation is made from",
+        "type": Array [
+          Object {
+            "code": "Reference",
+            "targetProfile": Array [
+              "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+              "http://hl7.org/fhir/StructureDefinition/ImagingStudy",
+              "http://hl7.org/fhir/StructureDefinition/Media",
+              "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+              "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+              "http://hl7.org/fhir/StructureDefinition/vitalsigns",
+            ],
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": true,
+      "isPrimitive": false,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "derivedFrom",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "Reference",
+      ],
+    },
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "definition": Object {
+            "base": Object {
+              "max": "1",
+              "min": 0,
+              "path": "Element.id",
+            },
+            "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+            "id": "Observation.component.id",
+            "isModifier": false,
+            "isSummary": false,
+            "mapping": Array [
+              Object {
+                "identity": "rim",
+                "map": "n/a",
+              },
+            ],
+            "max": "1",
+            "min": 0,
+            "path": "Observation.component.id",
+            "representation": Array [
+              "xmlAttr",
+            ],
+            "short": "Unique id for inter-element referencing",
+            "type": Array [
+              Object {
+                "code": "http://hl7.org/fhirpath/System.String",
+                "extension": Array [
+                  Object {
+                    "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                    "valueUrl": "string",
+                  },
+                ],
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": false,
+          "isPrimitive": false,
+          "isRequired": false,
+          "isSlice": false,
+          "name": "id",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "http://hl7.org/fhirpath/System.String",
+          ],
+        },
+        Object {
+          "children": Array [],
+          "definition": Object {
+            "alias": Array [
+              "extensions",
+              "user content",
+            ],
+            "base": Object {
+              "max": "*",
+              "min": 0,
+              "path": "Element.extension",
+            },
+            "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+            "constraint": Array [
+              Object {
+                "expression": "hasValue() or (children().count() > id.count())",
+                "human": "All FHIR elements must have a @value or children",
+                "key": "ele-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                "xpath": "@value|f:*|h:div",
+              },
+              Object {
+                "expression": "extension.exists() != value.exists()",
+                "human": "Must have either extensions or value[x], not both",
+                "key": "ext-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Extension",
+                "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \\"value\\")])",
+              },
+            ],
+            "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+            "id": "Observation.component.extension",
+            "isModifier": false,
+            "isSummary": false,
+            "mapping": Array [
+              Object {
+                "identity": "rim",
+                "map": "n/a",
+              },
+            ],
+            "max": "*",
+            "min": 0,
+            "path": "Observation.component.extension",
+            "short": "Additional content defined by implementations",
+            "type": Array [
+              Object {
+                "code": "Extension",
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": true,
+          "isPrimitive": false,
+          "isRequired": false,
+          "isSlice": false,
+          "name": "extension",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "Extension",
+          ],
+        },
+        Object {
+          "children": Array [],
+          "definition": Object {
+            "alias": Array [
+              "extensions",
+              "user content",
+              "modifiers",
+            ],
+            "base": Object {
+              "max": "*",
+              "min": 0,
+              "path": "BackboneElement.modifierExtension",
+            },
+            "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+            "constraint": Array [
+              Object {
+                "expression": "hasValue() or (children().count() > id.count())",
+                "human": "All FHIR elements must have a @value or children",
+                "key": "ele-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                "xpath": "@value|f:*|h:div",
+              },
+              Object {
+                "expression": "extension.exists() != value.exists()",
+                "human": "Must have either extensions or value[x], not both",
+                "key": "ext-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Extension",
+                "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \\"value\\")])",
+              },
+            ],
+            "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.
+
+Modifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+            "id": "Observation.component.modifierExtension",
+            "isModifier": true,
+            "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+            "isSummary": true,
+            "mapping": Array [
+              Object {
+                "identity": "rim",
+                "map": "N/A",
+              },
+            ],
+            "max": "*",
+            "min": 0,
+            "path": "Observation.component.modifierExtension",
+            "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+            "short": "Extensions that cannot be ignored even if unrecognized",
+            "type": Array [
+              Object {
+                "code": "Extension",
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": true,
+          "isPrimitive": false,
+          "isRequired": false,
+          "isSlice": false,
+          "name": "modifierExtension",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "Extension",
+          ],
+        },
+        Object {
+          "children": Array [],
+          "definition": Object {
+            "base": Object {
+              "max": "1",
+              "min": 1,
+              "path": "Observation.component.code",
+            },
+            "binding": Object {
+              "description": "This identifies the vital sign result type.",
+              "extension": Array [
+                Object {
+                  "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                  "valueString": "VitalSigns",
+                },
+              ],
+              "strength": "extensible",
+              "valueSet": "http://hl7.org/fhir/ValueSet/observation-vitalsignresult",
+            },
+            "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+            "constraint": Array [
+              Object {
+                "expression": "hasValue() or (children().count() > id.count())",
+                "human": "All FHIR elements must have a @value or children",
+                "key": "ele-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                "xpath": "@value|f:*|h:div",
+              },
+            ],
+            "definition": "Describes what was observed. Sometimes this is called the observation \\"code\\".",
+            "id": "Observation.component.code",
+            "isModifier": false,
+            "isSummary": true,
+            "mapping": Array [
+              Object {
+                "identity": "w5",
+                "map": "FiveWs.what[x]",
+              },
+              Object {
+                "identity": "sct-concept",
+                "map": "< 363787002 |Observable entity| OR 
+< 386053000 |Evaluation procedure|",
+              },
+              Object {
+                "identity": "v2",
+                "map": "OBX-3",
+              },
+              Object {
+                "identity": "rim",
+                "map": "code",
+              },
+            ],
+            "max": "1",
+            "min": 1,
+            "mustSupport": true,
+            "path": "Observation.component.code",
+            "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+            "short": "Type of component observation (code / type)",
+            "type": Array [
+              Object {
+                "code": "CodeableConcept",
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": false,
+          "isPrimitive": false,
+          "isRequired": true,
+          "isSlice": false,
+          "name": "code",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "CodeableConcept",
+          ],
+        },
+        Object {
+          "children": Array [],
+          "definition": Object {
+            "base": Object {
+              "max": "1",
+              "min": 0,
+              "path": "Observation.component.value[x]",
+            },
+            "binding": Object {
+              "description": "Common UCUM units for recording Vital Signs.",
+              "extension": Array [
+                Object {
+                  "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                  "valueString": "VitalSignsUnits",
+                },
+              ],
+              "strength": "required",
+              "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1",
+            },
+            "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+            "condition": Array [
+              "vs-3",
+            ],
+            "constraint": Array [
+              Object {
+                "expression": "hasValue() or (children().count() > id.count())",
+                "human": "All FHIR elements must have a @value or children",
+                "key": "ele-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                "xpath": "@value|f:*|h:div",
+              },
+            ],
+            "definition": "Vital Sign Value recorded with UCUM.",
+            "id": "Observation.component.value[x]",
+            "isModifier": false,
+            "isSummary": true,
+            "mapping": Array [
+              Object {
+                "identity": "sct-concept",
+                "map": "363714003 |Interprets| < 441742003 |Evaluation finding|",
+              },
+              Object {
+                "identity": "v2",
+                "map": "OBX.2, OBX.5, OBX.6",
+              },
+              Object {
+                "identity": "rim",
+                "map": "value",
+              },
+              Object {
+                "identity": "sct-attr",
+                "map": "363714003 |Interprets|",
+              },
+            ],
+            "max": "1",
+            "min": 0,
+            "mustSupport": true,
+            "path": "Observation.component.value[x]",
+            "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\\"PQ\\" (CONF:7305).",
+            "short": "Vital Sign Value recorded with UCUM",
+            "type": Array [
+              Object {
+                "code": "Quantity",
+              },
+              Object {
+                "code": "CodeableConcept",
+              },
+              Object {
+                "code": "string",
+              },
+              Object {
+                "code": "boolean",
+              },
+              Object {
+                "code": "integer",
+              },
+              Object {
+                "code": "Range",
+              },
+              Object {
+                "code": "Ratio",
+              },
+              Object {
+                "code": "SampledData",
+              },
+              Object {
+                "code": "time",
+              },
+              Object {
+                "code": "dateTime",
+              },
+              Object {
+                "code": "Period",
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": false,
+          "isPrimitive": false,
+          "isRequired": false,
+          "isSlice": false,
+          "name": "value[x]",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "Quantity",
+            "CodeableConcept",
+            "string",
+            "boolean",
+            "integer",
+            "Range",
+            "Ratio",
+            "SampledData",
+            "time",
+            "dateTime",
+            "Period",
+          ],
+        },
+        Object {
+          "children": Array [],
+          "definition": Object {
+            "base": Object {
+              "max": "1",
+              "min": 0,
+              "path": "Observation.component.dataAbsentReason",
+            },
+            "binding": Object {
+              "description": "Codes specifying why the result (\`Observation.value[x]\`) is missing.",
+              "extension": Array [
+                Object {
+                  "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                  "valueString": "ObservationValueAbsentReason",
+                },
+              ],
+              "strength": "extensible",
+              "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason",
+            },
+            "comment": "\\"Null\\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \\"detected\\", \\"not detected\\", \\"inconclusive\\", or  \\"test not done\\". 
+
+The alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \\"error\\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+            "condition": Array [
+              "obs-6",
+              "vs-3",
+            ],
+            "constraint": Array [
+              Object {
+                "expression": "hasValue() or (children().count() > id.count())",
+                "human": "All FHIR elements must have a @value or children",
+                "key": "ele-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                "xpath": "@value|f:*|h:div",
+              },
+            ],
+            "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+            "id": "Observation.component.dataAbsentReason",
+            "isModifier": false,
+            "isSummary": false,
+            "mapping": Array [
+              Object {
+                "identity": "v2",
+                "map": "N/A",
+              },
+              Object {
+                "identity": "rim",
+                "map": "value.nullFlavor",
+              },
+            ],
+            "max": "1",
+            "min": 0,
+            "mustSupport": true,
+            "path": "Observation.component.dataAbsentReason",
+            "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+            "short": "Why the component result is missing",
+            "type": Array [
+              Object {
+                "code": "CodeableConcept",
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": false,
+          "isPrimitive": false,
+          "isRequired": false,
+          "isSlice": false,
+          "name": "dataAbsentReason",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "CodeableConcept",
+          ],
+        },
+        Object {
+          "children": Array [],
+          "definition": Object {
+            "alias": Array [
+              "Abnormal Flag",
+            ],
+            "base": Object {
+              "max": "*",
+              "min": 0,
+              "path": "Observation.component.interpretation",
+            },
+            "binding": Object {
+              "description": "Codes identifying interpretations of observations.",
+              "extension": Array [
+                Object {
+                  "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                  "valueString": "ObservationInterpretation",
+                },
+              ],
+              "strength": "extensible",
+              "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation",
+            },
+            "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+            "constraint": Array [
+              Object {
+                "expression": "hasValue() or (children().count() > id.count())",
+                "human": "All FHIR elements must have a @value or children",
+                "key": "ele-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                "xpath": "@value|f:*|h:div",
+              },
+            ],
+            "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+            "id": "Observation.component.interpretation",
+            "isModifier": false,
+            "isSummary": false,
+            "mapping": Array [
+              Object {
+                "identity": "sct-concept",
+                "map": "< 260245000 |Findings values|",
+              },
+              Object {
+                "identity": "v2",
+                "map": "OBX-8",
+              },
+              Object {
+                "identity": "rim",
+                "map": "interpretationCode",
+              },
+              Object {
+                "identity": "sct-attr",
+                "map": "363713009 |Has interpretation|",
+              },
+            ],
+            "max": "*",
+            "min": 0,
+            "path": "Observation.component.interpretation",
+            "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+            "short": "High, low, normal, etc.",
+            "type": Array [
+              Object {
+                "code": "CodeableConcept",
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": true,
+          "isPrimitive": false,
+          "isRequired": false,
+          "isSlice": false,
+          "name": "interpretation",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "CodeableConcept",
+          ],
+        },
+        Object {
+          "children": Array [],
+          "definition": Object {
+            "base": Object {
+              "max": "*",
+              "min": 0,
+              "path": "Observation.component.referenceRange",
+            },
+            "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+            "constraint": Array [
+              Object {
+                "expression": "hasValue() or (children().count() > id.count())",
+                "human": "All FHIR elements must have a @value or children",
+                "key": "ele-1",
+                "severity": "error",
+                "source": "http://hl7.org/fhir/StructureDefinition/Element",
+                "xpath": "@value|f:*|h:div",
+              },
+            ],
+            "contentReference": "#Observation.referenceRange",
+            "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+            "id": "Observation.component.referenceRange",
+            "isModifier": false,
+            "isSummary": false,
+            "mapping": Array [
+              Object {
+                "identity": "v2",
+                "map": "OBX.7",
+              },
+              Object {
+                "identity": "rim",
+                "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]",
+              },
+            ],
+            "max": "*",
+            "min": 0,
+            "path": "Observation.component.referenceRange",
+            "requirements": "Knowing what values are considered \\"normal\\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+            "short": "Provides guide for interpretation of component result",
+          },
+          "index": undefined,
+          "isArray": true,
+          "isPrimitive": false,
+          "isRequired": false,
+          "isSlice": false,
+          "name": "referenceRange",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [],
+        },
+      ],
+      "definition": Object {
+        "base": Object {
+          "max": "*",
+          "min": 0,
+          "path": "Observation.component",
+        },
+        "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+        "constraint": Array [
+          Object {
+            "expression": "hasValue() or (children().count() > id.count())",
+            "human": "All FHIR elements must have a @value or children",
+            "key": "ele-1",
+            "severity": "error",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element",
+            "xpath": "@value|f:*|h:div",
+          },
+          Object {
+            "expression": "value.exists() or dataAbsentReason.exists()",
+            "human": "If there is no a value a data absent reason must be present",
+            "key": "vs-3",
+            "severity": "error",
+            "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+          },
+        ],
+        "definition": "Used when reporting systolic and diastolic blood pressure.",
+        "id": "Observation.component",
+        "isModifier": false,
+        "isSummary": true,
+        "mapping": Array [
+          Object {
+            "identity": "v2",
+            "map": "containment by OBX-4?",
+          },
+          Object {
+            "identity": "rim",
+            "map": "outBoundRelationship[typeCode=COMP]",
+          },
+        ],
+        "max": "*",
+        "min": 0,
+        "mustSupport": true,
+        "path": "Observation.component",
+        "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+        "short": "Used when reporting systolic and diastolic blood pressure.",
+        "type": Array [
+          Object {
+            "code": "BackboneElement",
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": true,
+      "isPrimitive": false,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "component",
+      "parent": undefined,
+      "slices": Array [],
+      "types": Array [
+        "BackboneElement",
+      ],
+    },
+  ],
+  "meta": Object {
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/vitalsigns",
+    "constraint": Array [
+      Object {
+        "expression": "contained.contained.empty()",
+        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+        "key": "dom-2",
+        "severity": "error",
+        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource",
+        "xpath": "not(parent::f:contained and f:contained)",
+      },
+      Object {
+        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+        "key": "dom-3",
+        "severity": "error",
+        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource",
+        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+      },
+      Object {
+        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+        "key": "dom-4",
+        "severity": "error",
+        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource",
+        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+      },
+      Object {
+        "expression": "contained.meta.security.empty()",
+        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+        "key": "dom-5",
+        "severity": "error",
+        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource",
+        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+      },
+      Object {
+        "expression": "text.\`div\`.exists()",
+        "extension": Array [
+          Object {
+            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+            "valueBoolean": true,
+          },
+          Object {
+            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+            "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time.",
+          },
+        ],
+        "human": "A resource should have narrative for robust management",
+        "key": "dom-6",
+        "severity": "warning",
+        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource",
+        "xpath": "exists(f:text/h:div)",
+      },
+      Object {
+        "expression": "dataAbsentReason.empty() or value.empty()",
+        "human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
+        "key": "obs-6",
+        "severity": "error",
+        "source": "http://hl7.org/fhir/StructureDefinition/Observation",
+        "xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
+      },
+      Object {
+        "expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
+        "human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
+        "key": "obs-7",
+        "severity": "error",
+        "source": "http://hl7.org/fhir/StructureDefinition/Observation",
+        "xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
+      },
+      Object {
+        "expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
+        "human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
+        "key": "vs-2",
+        "severity": "error",
+        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns",
+        "xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+      },
+    ],
+    "derivation": "constraint",
+    "description": "FHIR Heart Rate Profile",
+    "id": "heartrate",
+    "kind": "resource",
+    "max": "*",
+    "min": 0,
+    "name": "observation-heartrate",
+    "publisher": "Health Level Seven International (Orders and Observations Workgroup)",
+    "type": "Observation",
+    "url": "http://hl7.org/fhir/StructureDefinition/heartrate",
+  },
+}
+`;
+
+exports[`structurize handles slices (snapshot 1`] = `
+Object {
+  "attributes": Array [
+    Object {
+      "children": Array [],
+      "definition": Object {
+        "base": Object {
+          "max": "1",
+          "min": 0,
+          "path": "Resource.id",
+        },
+        "id": "Mock.a",
+        "max": "*",
+        "min": 0,
+        "path": "Mock.a",
+        "type": Array [
+          Object {
+            "code": "string",
+          },
+        ],
+      },
+      "index": undefined,
+      "isArray": true,
+      "isPrimitive": true,
+      "isRequired": false,
+      "isSlice": false,
+      "name": "a",
+      "parent": undefined,
+      "slices": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "definition": Object {
+                "base": Object {
+                  "max": "1",
+                  "min": 0,
+                  "path": "Resource.id",
+                },
+                "id": "Mock.a:SomeSlice.b",
+                "max": "1",
+                "min": 0,
+                "path": "Mock.a.b",
+                "type": Array [
+                  Object {
+                    "code": "string",
+                  },
+                ],
+              },
+              "index": undefined,
+              "isArray": false,
+              "isPrimitive": true,
+              "isRequired": false,
+              "isSlice": false,
+              "name": "b",
+              "parent": undefined,
+              "slices": Array [],
+              "types": Array [
+                "string",
+              ],
+            },
+          ],
+          "definition": Object {
+            "base": Object {
+              "max": "1",
+              "min": 0,
+              "path": "Resource.id",
+            },
+            "id": "Mock.a:SomeSlice",
+            "max": "1",
+            "min": 1,
+            "path": "Mock.a",
+            "sliceName": "SomeSlice",
+            "type": Array [
+              Object {
+                "code": "string",
+              },
+            ],
+          },
+          "index": undefined,
+          "isArray": false,
+          "isPrimitive": true,
+          "isRequired": true,
+          "isSlice": true,
+          "name": "a:SomeSlice",
+          "parent": undefined,
+          "slices": Array [],
+          "types": Array [
+            "string",
+          ],
+        },
+      ],
+      "types": Array [
+        "string",
+      ],
+    },
+  ],
+  "meta": Object {
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/super-mock",
+    "constraint": Array [
+      Object {
+        "expression": "contained.contained.empty()",
+        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+        "key": "dom-2",
+        "severity": "error",
+        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource",
+        "xpath": "not(parent::f:contained and f:contained)",
+      },
+    ],
+    "derivation": "constraint",
+    "description": "Mock profile with a slice",
+    "id": "mock",
+    "kind": "resource",
+    "max": "1",
+    "min": 0,
+    "name": "Mock",
+    "publisher": "Arkhn dev team",
+    "type": "Mock",
+    "url": "http://hl7.org/fhir/StructureDefinition/mock",
+  },
+}
+`;

--- a/tests/definition.test.ts
+++ b/tests/definition.test.ts
@@ -1,0 +1,126 @@
+import { structurize, isChildOf } from 'definition'
+
+import * as heartrateProfile from './fixtures/heartrate-profile.json'
+import * as mockDefinition from './fixtures/mockDefinition.json'
+import * as definitionWithSlices from './fixtures/definitionWithSlices.json'
+import { AttributeDefinition } from 'types'
+
+describe('isChildOf', () => {
+  it('returns true if a definition is a parent of the other', () => {
+    const parent = {
+      path: 'Resource.a',
+    } as AttributeDefinition
+    const child = {
+      path: 'Resource.a.b',
+    } as AttributeDefinition
+    expect(isChildOf(child, parent)).toBe(true)
+  })
+
+  it('works with nested path', () => {
+    const parent = {
+      path: 'Resource.a.b.c.d',
+    } as AttributeDefinition
+    const child = {
+      path: 'Resource.a.b.c.d.e',
+    } as AttributeDefinition
+    expect(isChildOf(child, parent)).toBe(true)
+  })
+
+  it('returns false when path do not match', () => {
+    const parent = {
+      path: 'Resource.a',
+    } as AttributeDefinition
+    const child = {
+      path: 'Resource.b',
+    } as AttributeDefinition
+    expect(isChildOf(child, parent)).toBe(false)
+  })
+
+  it('returns false when path are equal', () => {
+    const parent = {
+      path: 'Resource.a',
+    } as AttributeDefinition
+    const child = {
+      path: 'Resource.a',
+    } as AttributeDefinition
+    expect(isChildOf(child, parent)).toBe(false)
+  })
+})
+
+describe('structurize', () => {
+  it('builds a structured version of a mock StructureDefinition (snapshot)', () => {
+    const structured = structurize(mockDefinition.resource)
+    expect(structured).toMatchSnapshot()
+  })
+
+  it('builds a structured version of a real StructureDefinition (snapshot)', () => {
+    const structured = structurize(heartrateProfile.resource)
+    expect(structured).toMatchSnapshot()
+  })
+
+  it('builds a structured version of a mock StructureDefinition', () => {
+    const structured = structurize(mockDefinition.resource)
+
+    expect(structured.meta).toEqual({
+      baseDefinition: 'http://hl7.org/fhir/StructureDefinition/super-mock',
+      constraint: [
+        {
+          key: 'dom-2',
+          severity: 'error',
+          human:
+            'If the resource is contained in another resource, it SHALL NOT contain nested Resources',
+          expression: 'contained.contained.empty()',
+          xpath: 'not(parent::f:contained and f:contained)',
+          source: 'http://hl7.org/fhir/StructureDefinition/DomainResource',
+        },
+      ],
+      derivation: 'constraint',
+      description: 'FHIR Heart Rate Profile',
+      id: 'mock',
+      kind: 'resource',
+      max: '1',
+      min: 0,
+      name: 'Mock',
+      publisher: 'Arkhn dev team',
+      type: 'Mock',
+      url: 'http://hl7.org/fhir/StructureDefinition/mock',
+    })
+
+    expect(structured.attributes).toHaveLength(2)
+    expect(structured.attributes![0].children).toHaveLength(2)
+    expect(structured.attributes![0].children[0].children).toHaveLength(1)
+    expect(
+      structured.attributes![0].children[0].children[0].children,
+    ).toHaveLength(0)
+    expect(structured.attributes![0].children[1].children).toHaveLength(0)
+    expect(structured.attributes![1].children).toHaveLength(1)
+    expect(structured.attributes![1].children[0].children).toHaveLength(0)
+  })
+
+  it('handles primitive types', () => {
+    const structured = structurize({
+      resourceType: 'StructureDefinition',
+      id: 'mock',
+      kind: 'primitive-type',
+      derivation: 'constraint',
+      snapshot: { element: [{}] },
+    })
+    expect(structured.attributes).not.toBeDefined()
+    expect(structured.meta).toMatchObject({ kind: 'primitive-type' })
+  })
+
+  it('handles slices (snapshot', () => {
+    const structured = structurize(definitionWithSlices.resource)
+
+    expect(structured).toMatchSnapshot()
+  })
+
+  it('handles slices', () => {
+    const structured = structurize(definitionWithSlices.resource)
+
+    expect(structured.attributes).toHaveLength(1)
+    expect(structured.attributes![0].children).toHaveLength(0)
+    expect(structured.attributes![0].slices).toHaveLength(1)
+    expect(structured.attributes![0].slices[0].children).toHaveLength(1)
+  })
+})

--- a/tests/definition.test.ts
+++ b/tests/definition.test.ts
@@ -48,6 +48,12 @@ describe('isChildOf', () => {
 })
 
 describe('structurize', () => {
+  it('raises when the snapshot is missing', () => {
+    expect(() => structurize({})).toThrowErrorMatchingInlineSnapshot(
+      `"Snapshot is needed in the structure definition."`,
+    )
+  })
+
   it('builds a structured version of a mock StructureDefinition (snapshot)', () => {
     const structured = structurize(mockDefinition.resource)
     expect(structured).toMatchSnapshot()

--- a/tests/fixtures/definitionWithSlices.json
+++ b/tests/fixtures/definitionWithSlices.json
@@ -1,0 +1,88 @@
+{
+  "fullUrl": "http://hl7.org/fhir/StructureDefinition/mock",
+  "resource": {
+    "resourceType": "StructureDefinition",
+    "id": "mock",
+    "url": "http://hl7.org/fhir/StructureDefinition/mock",
+    "version": "4.0.1",
+    "name": "Mock",
+    "title": "Mock Profile",
+    "date": "2018-08-11",
+    "publisher": "Arkhn dev team",
+    "description": "Mock profile with a slice",
+    "fhirVersion": "4.0.1",
+    "kind": "resource",
+    "type": "Mock",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/super-mock",
+    "derivation": "constraint",
+    "snapshot": {
+      "element": [
+        {
+          "id": "Mock",
+          "path": "Mock",
+          "min": 0,
+          "max": "1",
+          "constraint": [
+            {
+              "key": "dom-2",
+              "severity": "error",
+              "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+              "expression": "contained.contained.empty()",
+              "xpath": "not(parent::f:contained and f:contained)",
+              "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+            }
+          ]
+        },
+        {
+          "id": "Mock.a",
+          "path": "Mock.a",
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Resource.id",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "string"
+            }
+          ]
+        },
+        {
+          "id": "Mock.a:SomeSlice",
+          "path": "Mock.a",
+          "sliceName": "SomeSlice",
+          "min": 1,
+          "max": "1",
+          "base": {
+            "path": "Resource.id",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "string"
+            }
+          ]
+        },
+        {
+          "id": "Mock.a:SomeSlice.b",
+          "path": "Mock.a.b",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Resource.id",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "string"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/heartrate-profile.json
+++ b/tests/fixtures/heartrate-profile.json
@@ -1,0 +1,4328 @@
+{
+  "fullUrl": "http://hl7.org/fhir/StructureDefinition/heartrate",
+  "resource": {
+    "resourceType": "StructureDefinition",
+    "id": "heartrate",
+    "text": {
+      "status": "generated",
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">to do</div>"
+    },
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-summary",
+        "valueMarkdown": "#### Complete Summary of the Mandatory Requirements\r\r1.  One code in `Observation.code` which must have\r    -   a fixed `Observation.code.coding.system`=**'http ://loinc.org'**\r    -   a fixed  `Observation.code.coding.code`= **'8867-4'**\r    -   Other additional Codings are allowed in `Observation.code`- e.g. more specific LOINC\r        Codes, SNOMED CT concepts, system specific codes. All codes\r        SHALL have an system value\r1. Either one Observation.valueQuantity or, if there is no value, one code in Observation.DataAbsentReason\r   - Each Observation.valueQuantity must have:\r     - One numeric value in Observation.valueQuantity.value\r     - a fixed Observation.valueQuantity.system=\"http://unitsofmeasure.org\"\r     - a UCUM unit code in Observation.valueQuantity.code = **'/min'**"
+      },
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm",
+        "valueInteger": 5
+      },
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+        "valueCode": "oo"
+      },
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+        "valueCode": "trial-use"
+      }
+    ],
+    "url": "http://hl7.org/fhir/StructureDefinition/heartrate",
+    "version": "4.0.1",
+    "name": "observation-heartrate",
+    "title": "Observation Heart Rate Profile",
+    "status": "draft",
+    "experimental": false,
+    "date": "2018-08-11",
+    "publisher": "Health Level Seven International (Orders and Observations Workgroup)",
+    "contact": [
+      {
+        "telecom": [
+          {
+            "system": "url",
+            "value": "http://www.hl7.org/Special/committees/orders/index.cfm Orders and Observations"
+          }
+        ]
+      }
+    ],
+    "description": "FHIR Heart Rate Profile",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+      {
+        "identity": "workflow",
+        "uri": "http://hl7.org/fhir/workflow",
+        "name": "Workflow Pattern"
+      },
+      {
+        "identity": "sct-concept",
+        "uri": "http://snomed.info/conceptdomain",
+        "name": "SNOMED CT Concept Domain Binding"
+      },
+      {
+        "identity": "v2",
+        "uri": "http://hl7.org/v2",
+        "name": "HL7 v2 Mapping"
+      },
+      {
+        "identity": "rim",
+        "uri": "http://hl7.org/v3",
+        "name": "RIM Mapping"
+      },
+      {
+        "identity": "w5",
+        "uri": "http://hl7.org/fhir/fivews",
+        "name": "FiveWs Pattern Mapping"
+      },
+      {
+        "identity": "sct-attr",
+        "uri": "http://snomed.org/attributebinding",
+        "name": "SNOMED CT Attribute Binding"
+      }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Observation",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/vitalsigns",
+    "derivation": "constraint",
+    "snapshot": {
+      "element": [
+        {
+          "id": "Observation",
+          "path": "Observation",
+          "short": "FHIR Heart Rate Profile",
+          "definition": "This profile defines how to represent heart rate observations in FHIR using a standard LOINC code and UCUM units of measure.",
+          "comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
+          "alias": ["Vital Signs", "Measurement", "Results", "Tests"],
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Observation",
+            "min": 0,
+            "max": "*"
+          },
+          "constraint": [
+            {
+              "key": "dom-2",
+              "severity": "error",
+              "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+              "expression": "contained.contained.empty()",
+              "xpath": "not(parent::f:contained and f:contained)",
+              "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+            },
+            {
+              "key": "dom-3",
+              "severity": "error",
+              "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+              "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+              "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+              "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+            },
+            {
+              "key": "dom-4",
+              "severity": "error",
+              "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+              "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+              "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+              "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+            },
+            {
+              "key": "dom-5",
+              "severity": "error",
+              "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+              "expression": "contained.meta.security.empty()",
+              "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+              "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                  "valueBoolean": true
+                },
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                  "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                }
+              ],
+              "key": "dom-6",
+              "severity": "warning",
+              "human": "A resource should have narrative for robust management",
+              "expression": "text.`div`.exists()",
+              "xpath": "exists(f:text/h:div)",
+              "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+            },
+            {
+              "key": "obs-6",
+              "severity": "error",
+              "human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
+              "expression": "dataAbsentReason.empty() or value.empty()",
+              "xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
+              "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+            },
+            {
+              "key": "obs-7",
+              "severity": "error",
+              "human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
+              "expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
+              "xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
+              "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+            },
+            {
+              "key": "vs-2",
+              "severity": "error",
+              "human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
+              "expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
+              "xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+              "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "Entity. Role, or Act"
+            },
+            {
+              "identity": "workflow",
+              "map": "Event"
+            },
+            {
+              "identity": "sct-concept",
+              "map": "< 363787002 |Observable entity|"
+            },
+            {
+              "identity": "v2",
+              "map": "OBX"
+            },
+            {
+              "identity": "rim",
+              "map": "Observation[classCode=OBS, moodCode=EVN]"
+            }
+          ]
+        },
+        {
+          "id": "Observation.id",
+          "path": "Observation.id",
+          "short": "Logical id of this artifact",
+          "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+          "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Resource.id",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                  "valueUrl": "string"
+                }
+              ],
+              "code": "http://hl7.org/fhirpath/System.String"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": true
+        },
+        {
+          "id": "Observation.meta",
+          "path": "Observation.meta",
+          "short": "Metadata about the resource",
+          "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Resource.meta",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "Meta"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": true
+        },
+        {
+          "id": "Observation.implicitRules",
+          "path": "Observation.implicitRules",
+          "short": "A set of rules under which this content was created",
+          "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+          "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Resource.implicitRules",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "uri"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": true,
+          "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+          "isSummary": true
+        },
+        {
+          "id": "Observation.language",
+          "path": "Observation.language",
+          "short": "Language of the resource content",
+          "definition": "The base language in which the resource is written.",
+          "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Resource.language",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "binding": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+              },
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                "valueString": "Language"
+              },
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                "valueBoolean": true
+              }
+            ],
+            "strength": "preferred",
+            "description": "A human language.",
+            "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+          }
+        },
+        {
+          "id": "Observation.text",
+          "path": "Observation.text",
+          "short": "Text summary of the resource, for human interpretation",
+          "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+          "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+          "alias": ["narrative", "html", "xhtml", "display"],
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "DomainResource.text",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "Narrative"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "Act.text?"
+            }
+          ]
+        },
+        {
+          "id": "Observation.contained",
+          "path": "Observation.contained",
+          "short": "Contained, inline Resources",
+          "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+          "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+          "alias": [
+            "inline resources",
+            "anonymous resources",
+            "contained resources"
+          ],
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "DomainResource.contained",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Resource"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            }
+          ]
+        },
+        {
+          "id": "Observation.extension",
+          "path": "Observation.extension",
+          "short": "Additional content defined by implementations",
+          "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "alias": ["extensions", "user content"],
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "DomainResource.extension",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            },
+            {
+              "key": "ext-1",
+              "severity": "error",
+              "human": "Must have either extensions or value[x], not both",
+              "expression": "extension.exists() != value.exists()",
+              "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+              "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            }
+          ]
+        },
+        {
+          "id": "Observation.modifierExtension",
+          "path": "Observation.modifierExtension",
+          "short": "Extensions that cannot be ignored",
+          "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+          "alias": ["extensions", "user content"],
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "DomainResource.modifierExtension",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            },
+            {
+              "key": "ext-1",
+              "severity": "error",
+              "human": "Must have either extensions or value[x], not both",
+              "expression": "extension.exists() != value.exists()",
+              "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+              "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+            }
+          ],
+          "isModifier": true,
+          "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            }
+          ]
+        },
+        {
+          "id": "Observation.identifier",
+          "path": "Observation.identifier",
+          "short": "Business Identifier for observation",
+          "definition": "A unique identifier assigned to this observation.",
+          "requirements": "Allows observations to be distinguished and referenced.",
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Observation.identifier",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Identifier"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "workflow",
+              "map": "Event.identifier"
+            },
+            {
+              "identity": "w5",
+              "map": "FiveWs.identifier"
+            },
+            {
+              "identity": "v2",
+              "map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
+            },
+            {
+              "identity": "rim",
+              "map": "id"
+            }
+          ]
+        },
+        {
+          "id": "Observation.basedOn",
+          "path": "Observation.basedOn",
+          "short": "Fulfills plan, proposal or order",
+          "definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
+          "requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
+          "alias": ["Fulfills"],
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Observation.basedOn",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Reference",
+              "targetProfile": [
+                "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+                "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+              ]
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "workflow",
+              "map": "Event.basedOn"
+            },
+            {
+              "identity": "v2",
+              "map": "ORC"
+            },
+            {
+              "identity": "rim",
+              "map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
+            }
+          ]
+        },
+        {
+          "id": "Observation.partOf",
+          "path": "Observation.partOf",
+          "short": "Part of referenced event",
+          "definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
+          "comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
+          "alias": ["Container"],
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Observation.partOf",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Reference",
+              "targetProfile": [
+                "http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
+                "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
+                "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+                "http://hl7.org/fhir/StructureDefinition/Procedure",
+                "http://hl7.org/fhir/StructureDefinition/Immunization",
+                "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+              ]
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "workflow",
+              "map": "Event.partOf"
+            },
+            {
+              "identity": "v2",
+              "map": "Varies by domain"
+            },
+            {
+              "identity": "rim",
+              "map": ".outboundRelationship[typeCode=FLFS].target"
+            }
+          ]
+        },
+        {
+          "id": "Observation.status",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
+              "valueString": "default: final"
+            }
+          ],
+          "path": "Observation.status",
+          "short": "registered | preliminary | final | amended +",
+          "definition": "The status of the result value.",
+          "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+          "requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
+          "min": 1,
+          "max": "1",
+          "base": {
+            "path": "Observation.status",
+            "min": 1,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "mustSupport": true,
+          "isModifier": true,
+          "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+          "isSummary": true,
+          "binding": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                "valueString": "Status"
+              }
+            ],
+            "strength": "required",
+            "valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
+          },
+          "mapping": [
+            {
+              "identity": "workflow",
+              "map": "Event.status"
+            },
+            {
+              "identity": "w5",
+              "map": "FiveWs.status"
+            },
+            {
+              "identity": "sct-concept",
+              "map": "< 445584004 |Report by finality status|"
+            },
+            {
+              "identity": "v2",
+              "map": "OBX-11"
+            },
+            {
+              "identity": "rim",
+              "map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
+            }
+          ]
+        },
+        {
+          "id": "Observation.category",
+          "path": "Observation.category",
+          "slicing": {
+            "discriminator": [
+              {
+                "type": "value",
+                "path": "coding.code"
+              },
+              {
+                "type": "value",
+                "path": "coding.system"
+              }
+            ],
+            "ordered": false,
+            "rules": "open"
+          },
+          "short": "Classification of  type of observation",
+          "definition": "A code that classifies the general type of observation being made.",
+          "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+          "requirements": "Used for filtering what observations are retrieved and displayed.",
+          "min": 1,
+          "max": "*",
+          "base": {
+            "path": "Observation.category",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "CodeableConcept"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "mustSupport": true,
+          "isModifier": false,
+          "isSummary": false,
+          "binding": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                "valueString": "ObservationCategory"
+              }
+            ],
+            "strength": "preferred",
+            "description": "Codes for high level observation categories.",
+            "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+          },
+          "mapping": [
+            {
+              "identity": "w5",
+              "map": "FiveWs.class"
+            },
+            {
+              "identity": "rim",
+              "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+            }
+          ]
+        },
+        {
+          "id": "Observation.category:VSCat",
+          "path": "Observation.category",
+          "sliceName": "VSCat",
+          "short": "Classification of  type of observation",
+          "definition": "A code that classifies the general type of observation being made.",
+          "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+          "requirements": "Used for filtering what observations are retrieved and displayed.",
+          "min": 1,
+          "max": "1",
+          "base": {
+            "path": "Observation.category",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "CodeableConcept"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "mustSupport": true,
+          "isModifier": false,
+          "isSummary": false,
+          "binding": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                "valueString": "ObservationCategory"
+              }
+            ],
+            "strength": "preferred",
+            "description": "Codes for high level observation categories.",
+            "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+          },
+          "mapping": [
+            {
+              "identity": "w5",
+              "map": "FiveWs.class"
+            },
+            {
+              "identity": "rim",
+              "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+            }
+          ]
+        },
+        {
+          "id": "Observation.category:VSCat.id",
+          "path": "Observation.category.id",
+          "representation": ["xmlAttr"],
+          "short": "Unique id for inter-element referencing",
+          "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Element.id",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                  "valueUrl": "string"
+                }
+              ],
+              "code": "http://hl7.org/fhirpath/System.String"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ]
+        },
+        {
+          "id": "Observation.category:VSCat.extension",
+          "path": "Observation.category.extension",
+          "slicing": {
+            "discriminator": [
+              {
+                "type": "value",
+                "path": "url"
+              }
+            ],
+            "description": "Extensions are always sliced by (at least) url",
+            "rules": "open"
+          },
+          "short": "Additional content defined by implementations",
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "alias": ["extensions", "user content"],
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Element.extension",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            },
+            {
+              "key": "ext-1",
+              "severity": "error",
+              "human": "Must have either extensions or value[x], not both",
+              "expression": "extension.exists() != value.exists()",
+              "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+              "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ]
+        },
+        {
+          "id": "Observation.category:VSCat.coding",
+          "path": "Observation.category.coding",
+          "short": "Code defined by a terminology system",
+          "definition": "A reference to a code defined by a terminology system.",
+          "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+          "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+          "min": 1,
+          "max": "*",
+          "base": {
+            "path": "CodeableConcept.coding",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Coding"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "mustSupport": true,
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "C*E.1-8, C*E.10-22"
+            },
+            {
+              "identity": "rim",
+              "map": "union(., ./translation)"
+            },
+            {
+              "identity": "orim",
+              "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+            }
+          ]
+        },
+        {
+          "id": "Observation.category:VSCat.coding.id",
+          "path": "Observation.category.coding.id",
+          "representation": ["xmlAttr"],
+          "short": "Unique id for inter-element referencing",
+          "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Element.id",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                  "valueUrl": "string"
+                }
+              ],
+              "code": "http://hl7.org/fhirpath/System.String"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ]
+        },
+        {
+          "id": "Observation.category:VSCat.coding.extension",
+          "path": "Observation.category.coding.extension",
+          "slicing": {
+            "discriminator": [
+              {
+                "type": "value",
+                "path": "url"
+              }
+            ],
+            "description": "Extensions are always sliced by (at least) url",
+            "rules": "open"
+          },
+          "short": "Additional content defined by implementations",
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "alias": ["extensions", "user content"],
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Element.extension",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            },
+            {
+              "key": "ext-1",
+              "severity": "error",
+              "human": "Must have either extensions or value[x], not both",
+              "expression": "extension.exists() != value.exists()",
+              "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+              "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ]
+        },
+        {
+          "id": "Observation.category:VSCat.coding.system",
+          "path": "Observation.category.coding.system",
+          "short": "Identity of the terminology system",
+          "definition": "The identification of the code system that defines the meaning of the symbol in the code.",
+          "comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
+          "requirements": "Need to be unambiguous about the source of the definition of the symbol.",
+          "min": 1,
+          "max": "1",
+          "base": {
+            "path": "Coding.system",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "uri"
+            }
+          ],
+          "fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "mustSupport": true,
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "C*E.3"
+            },
+            {
+              "identity": "rim",
+              "map": "./codeSystem"
+            },
+            {
+              "identity": "orim",
+              "map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
+            }
+          ]
+        },
+        {
+          "id": "Observation.category:VSCat.coding.version",
+          "path": "Observation.category.coding.version",
+          "short": "Version of the system - if relevant",
+          "definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
+          "comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Coding.version",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "C*E.7"
+            },
+            {
+              "identity": "rim",
+              "map": "./codeSystemVersion"
+            },
+            {
+              "identity": "orim",
+              "map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
+            }
+          ]
+        },
+        {
+          "id": "Observation.category:VSCat.coding.code",
+          "path": "Observation.category.coding.code",
+          "short": "Symbol in syntax defined by the system",
+          "definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
+          "requirements": "Need to refer to a particular code in the system.",
+          "min": 1,
+          "max": "1",
+          "base": {
+            "path": "Coding.code",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "fixedCode": "vital-signs",
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "mustSupport": true,
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "C*E.1"
+            },
+            {
+              "identity": "rim",
+              "map": "./code"
+            },
+            {
+              "identity": "orim",
+              "map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
+            }
+          ]
+        },
+        {
+          "id": "Observation.category:VSCat.coding.display",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+              "valueBoolean": true
+            }
+          ],
+          "path": "Observation.category.coding.display",
+          "short": "Representation defined by the system",
+          "definition": "A representation of the meaning of the code in the system, following the rules of the system.",
+          "requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Coding.display",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "C*E.2 - but note this is not well followed"
+            },
+            {
+              "identity": "rim",
+              "map": "CV.displayName"
+            },
+            {
+              "identity": "orim",
+              "map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
+            }
+          ]
+        },
+        {
+          "id": "Observation.category:VSCat.coding.userSelected",
+          "path": "Observation.category.coding.userSelected",
+          "short": "If this coding was chosen directly by the user",
+          "definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
+          "comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
+          "requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Coding.userSelected",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "boolean"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "Sometimes implied by being first"
+            },
+            {
+              "identity": "rim",
+              "map": "CD.codingRationale"
+            },
+            {
+              "identity": "orim",
+              "map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
+            }
+          ]
+        },
+        {
+          "id": "Observation.category:VSCat.text",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+              "valueBoolean": true
+            }
+          ],
+          "path": "Observation.category.text",
+          "short": "Plain text representation of the concept",
+          "definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
+          "comment": "Very often the text is the same as a displayName of one of the codings.",
+          "requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "CodeableConcept.text",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "C*E.9. But note many systems use C*E.2 for this"
+            },
+            {
+              "identity": "rim",
+              "map": "./originalText[mediaType/code=\"text/plain\"]/data"
+            },
+            {
+              "identity": "orim",
+              "map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
+            }
+          ]
+        },
+        {
+          "id": "Observation.code",
+          "path": "Observation.code",
+          "short": "Heart Rate",
+          "definition": "Heart Rate.",
+          "comment": "additional codes that translate or map to this code are allowed.  For example a more granular LOINC code or code that is used locally in a system.",
+          "requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
+          "alias": ["Name", "Test"],
+          "min": 1,
+          "max": "1",
+          "base": {
+            "path": "Observation.code",
+            "min": 1,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "CodeableConcept"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "mustSupport": true,
+          "isModifier": false,
+          "isSummary": true,
+          "binding": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                "valueString": "VitalSigns"
+              }
+            ],
+            "strength": "extensible",
+            "description": "This identifies the vital sign result type.",
+            "valueSet": "http://hl7.org/fhir/ValueSet/observation-vitalsignresult"
+          },
+          "mapping": [
+            {
+              "identity": "workflow",
+              "map": "Event.code"
+            },
+            {
+              "identity": "w5",
+              "map": "FiveWs.what[x]"
+            },
+            {
+              "identity": "sct-concept",
+              "map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
+            },
+            {
+              "identity": "v2",
+              "map": "OBX-3"
+            },
+            {
+              "identity": "rim",
+              "map": "code"
+            },
+            {
+              "identity": "sct-attr",
+              "map": "116680003 |Is a|"
+            }
+          ]
+        },
+        {
+          "id": "Observation.code.id",
+          "path": "Observation.code.id",
+          "representation": ["xmlAttr"],
+          "short": "Unique id for inter-element referencing",
+          "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Element.id",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                  "valueUrl": "string"
+                }
+              ],
+              "code": "http://hl7.org/fhirpath/System.String"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ]
+        },
+        {
+          "id": "Observation.code.extension",
+          "path": "Observation.code.extension",
+          "slicing": {
+            "discriminator": [
+              {
+                "type": "value",
+                "path": "url"
+              }
+            ],
+            "description": "Extensions are always sliced by (at least) url",
+            "rules": "open"
+          },
+          "short": "Additional content defined by implementations",
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "alias": ["extensions", "user content"],
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Element.extension",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            },
+            {
+              "key": "ext-1",
+              "severity": "error",
+              "human": "Must have either extensions or value[x], not both",
+              "expression": "extension.exists() != value.exists()",
+              "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+              "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ]
+        },
+        {
+          "id": "Observation.code.coding",
+          "path": "Observation.code.coding",
+          "slicing": {
+            "discriminator": [
+              {
+                "type": "value",
+                "path": "code"
+              },
+              {
+                "type": "value",
+                "path": "system"
+              }
+            ],
+            "ordered": false,
+            "rules": "open"
+          },
+          "short": "Code defined by a terminology system",
+          "definition": "A reference to a code defined by a terminology system.",
+          "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+          "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "CodeableConcept.coding",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Coding"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "C*E.1-8, C*E.10-22"
+            },
+            {
+              "identity": "rim",
+              "map": "union(., ./translation)"
+            },
+            {
+              "identity": "orim",
+              "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+            }
+          ]
+        },
+        {
+          "id": "Observation.code.coding:HeartRateCode",
+          "path": "Observation.code.coding",
+          "sliceName": "HeartRateCode",
+          "short": "Code defined by a terminology system",
+          "definition": "A reference to a code defined by a terminology system.",
+          "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+          "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+          "min": 1,
+          "max": "1",
+          "base": {
+            "path": "CodeableConcept.coding",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Coding"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "C*E.1-8, C*E.10-22"
+            },
+            {
+              "identity": "rim",
+              "map": "union(., ./translation)"
+            },
+            {
+              "identity": "orim",
+              "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+            }
+          ]
+        },
+        {
+          "id": "Observation.code.coding:HeartRateCode.id",
+          "path": "Observation.code.coding.id",
+          "representation": ["xmlAttr"],
+          "short": "Unique id for inter-element referencing",
+          "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Element.id",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                  "valueUrl": "string"
+                }
+              ],
+              "code": "http://hl7.org/fhirpath/System.String"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ]
+        },
+        {
+          "id": "Observation.code.coding:HeartRateCode.extension",
+          "path": "Observation.code.coding.extension",
+          "slicing": {
+            "discriminator": [
+              {
+                "type": "value",
+                "path": "url"
+              }
+            ],
+            "description": "Extensions are always sliced by (at least) url",
+            "rules": "open"
+          },
+          "short": "Additional content defined by implementations",
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "alias": ["extensions", "user content"],
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Element.extension",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            },
+            {
+              "key": "ext-1",
+              "severity": "error",
+              "human": "Must have either extensions or value[x], not both",
+              "expression": "extension.exists() != value.exists()",
+              "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+              "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ]
+        },
+        {
+          "id": "Observation.code.coding:HeartRateCode.system",
+          "path": "Observation.code.coding.system",
+          "short": "Identity of the terminology system",
+          "definition": "The identification of the code system that defines the meaning of the symbol in the code.",
+          "comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
+          "requirements": "Need to be unambiguous about the source of the definition of the symbol.",
+          "min": 1,
+          "max": "1",
+          "base": {
+            "path": "Coding.system",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "uri"
+            }
+          ],
+          "fixedUri": "http://loinc.org",
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "C*E.3"
+            },
+            {
+              "identity": "rim",
+              "map": "./codeSystem"
+            },
+            {
+              "identity": "orim",
+              "map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
+            }
+          ]
+        },
+        {
+          "id": "Observation.code.coding:HeartRateCode.version",
+          "path": "Observation.code.coding.version",
+          "short": "Version of the system - if relevant",
+          "definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
+          "comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Coding.version",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "C*E.7"
+            },
+            {
+              "identity": "rim",
+              "map": "./codeSystemVersion"
+            },
+            {
+              "identity": "orim",
+              "map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
+            }
+          ]
+        },
+        {
+          "id": "Observation.code.coding:HeartRateCode.code",
+          "path": "Observation.code.coding.code",
+          "short": "Symbol in syntax defined by the system",
+          "definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
+          "requirements": "Need to refer to a particular code in the system.",
+          "min": 1,
+          "max": "1",
+          "base": {
+            "path": "Coding.code",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "fixedCode": "8867-4",
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "C*E.1"
+            },
+            {
+              "identity": "rim",
+              "map": "./code"
+            },
+            {
+              "identity": "orim",
+              "map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
+            }
+          ]
+        },
+        {
+          "id": "Observation.code.coding:HeartRateCode.display",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+              "valueBoolean": true
+            }
+          ],
+          "path": "Observation.code.coding.display",
+          "short": "Representation defined by the system",
+          "definition": "A representation of the meaning of the code in the system, following the rules of the system.",
+          "requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Coding.display",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "C*E.2 - but note this is not well followed"
+            },
+            {
+              "identity": "rim",
+              "map": "CV.displayName"
+            },
+            {
+              "identity": "orim",
+              "map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
+            }
+          ]
+        },
+        {
+          "id": "Observation.code.coding:HeartRateCode.userSelected",
+          "path": "Observation.code.coding.userSelected",
+          "short": "If this coding was chosen directly by the user",
+          "definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
+          "comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
+          "requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Coding.userSelected",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "boolean"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "Sometimes implied by being first"
+            },
+            {
+              "identity": "rim",
+              "map": "CD.codingRationale"
+            },
+            {
+              "identity": "orim",
+              "map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
+            }
+          ]
+        },
+        {
+          "id": "Observation.code.text",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+              "valueBoolean": true
+            }
+          ],
+          "path": "Observation.code.text",
+          "short": "Plain text representation of the concept",
+          "definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
+          "comment": "Very often the text is the same as a displayName of one of the codings.",
+          "requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "CodeableConcept.text",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "C*E.9. But note many systems use C*E.2 for this"
+            },
+            {
+              "identity": "rim",
+              "map": "./originalText[mediaType/code=\"text/plain\"]/data"
+            },
+            {
+              "identity": "orim",
+              "map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
+            }
+          ]
+        },
+        {
+          "id": "Observation.subject",
+          "path": "Observation.subject",
+          "short": "Who and/or what the observation is about",
+          "definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
+          "comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
+          "requirements": "Observations have no value if you don't know who or what they're about.",
+          "min": 1,
+          "max": "1",
+          "base": {
+            "path": "Observation.subject",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "Reference",
+              "targetProfile": [
+                "http://hl7.org/fhir/StructureDefinition/Patient"
+              ]
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "mustSupport": true,
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "workflow",
+              "map": "Event.subject"
+            },
+            {
+              "identity": "w5",
+              "map": "FiveWs.subject[x]"
+            },
+            {
+              "identity": "v2",
+              "map": "PID-3"
+            },
+            {
+              "identity": "rim",
+              "map": "participation[typeCode=RTGT] "
+            },
+            {
+              "identity": "w5",
+              "map": "FiveWs.subject"
+            }
+          ]
+        },
+        {
+          "id": "Observation.focus",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+              "valueCode": "trial-use"
+            }
+          ],
+          "path": "Observation.focus",
+          "short": "What the observation is about, when it is not about the subject of record",
+          "definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
+          "comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Observation.focus",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Reference",
+              "targetProfile": [
+                "http://hl7.org/fhir/StructureDefinition/Resource"
+              ]
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "w5",
+              "map": "FiveWs.subject[x]"
+            },
+            {
+              "identity": "v2",
+              "map": "OBX-3"
+            },
+            {
+              "identity": "rim",
+              "map": "participation[typeCode=SBJ]"
+            },
+            {
+              "identity": "w5",
+              "map": "FiveWs.subject"
+            }
+          ]
+        },
+        {
+          "id": "Observation.encounter",
+          "path": "Observation.encounter",
+          "short": "Healthcare event during which this observation is made",
+          "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
+          "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
+          "requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
+          "alias": ["Context"],
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Observation.encounter",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "Reference",
+              "targetProfile": [
+                "http://hl7.org/fhir/StructureDefinition/Encounter"
+              ]
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "workflow",
+              "map": "Event.context"
+            },
+            {
+              "identity": "w5",
+              "map": "FiveWs.context"
+            },
+            {
+              "identity": "v2",
+              "map": "PV1"
+            },
+            {
+              "identity": "rim",
+              "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+            }
+          ]
+        },
+        {
+          "id": "Observation.effective[x]",
+          "path": "Observation.effective[x]",
+          "short": "Often just a dateTime for Vital Signs",
+          "definition": "Often just a dateTime for Vital Signs.",
+          "comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
+          "requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
+          "alias": ["Occurrence"],
+          "min": 1,
+          "max": "1",
+          "base": {
+            "path": "Observation.effective[x]",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "dateTime"
+            },
+            {
+              "code": "Period"
+            }
+          ],
+          "condition": ["vs-1"],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            },
+            {
+              "key": "vs-1",
+              "severity": "error",
+              "human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
+              "expression": "($this as dateTime).toString().length() >= 8",
+              "xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]"
+            }
+          ],
+          "mustSupport": true,
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "workflow",
+              "map": "Event.occurrence[x]"
+            },
+            {
+              "identity": "w5",
+              "map": "FiveWs.done[x]"
+            },
+            {
+              "identity": "v2",
+              "map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
+            },
+            {
+              "identity": "rim",
+              "map": "effectiveTime"
+            }
+          ]
+        },
+        {
+          "id": "Observation.issued",
+          "path": "Observation.issued",
+          "short": "Date/Time this version was made available",
+          "definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
+          "comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Observation.issued",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "instant"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "w5",
+              "map": "FiveWs.recorded"
+            },
+            {
+              "identity": "v2",
+              "map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
+            },
+            {
+              "identity": "rim",
+              "map": "participation[typeCode=AUT].time"
+            }
+          ]
+        },
+        {
+          "id": "Observation.performer",
+          "path": "Observation.performer",
+          "short": "Who is responsible for the observation",
+          "definition": "Who was responsible for asserting the observed value as \"true\".",
+          "requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Observation.performer",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Reference",
+              "targetProfile": [
+                "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                "http://hl7.org/fhir/StructureDefinition/Organization",
+                "http://hl7.org/fhir/StructureDefinition/CareTeam",
+                "http://hl7.org/fhir/StructureDefinition/Patient",
+                "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+              ]
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "workflow",
+              "map": "Event.performer.actor"
+            },
+            {
+              "identity": "w5",
+              "map": "FiveWs.actor"
+            },
+            {
+              "identity": "v2",
+              "map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
+            },
+            {
+              "identity": "rim",
+              "map": "participation[typeCode=PRF]"
+            }
+          ]
+        },
+        {
+          "id": "Observation.value[x]",
+          "path": "Observation.value[x]",
+          "slicing": {
+            "discriminator": [
+              {
+                "type": "type",
+                "path": "$this"
+              }
+            ],
+            "ordered": false,
+            "rules": "closed"
+          },
+          "short": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
+          "definition": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
+          "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+          "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Observation.value[x]",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "Quantity"
+            }
+          ],
+          "condition": ["obs-7", "vs-2"],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "mustSupport": true,
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "sct-concept",
+              "map": "< 441742003 |Evaluation finding|"
+            },
+            {
+              "identity": "v2",
+              "map": "OBX.2, OBX.5, OBX.6"
+            },
+            {
+              "identity": "rim",
+              "map": "value"
+            },
+            {
+              "identity": "sct-attr",
+              "map": "363714003 |Interprets|"
+            }
+          ]
+        },
+        {
+          "id": "Observation.value[x]:valueQuantity",
+          "path": "Observation.value[x]",
+          "sliceName": "valueQuantity",
+          "short": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
+          "definition": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
+          "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+          "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Observation.value[x]",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "Quantity"
+            }
+          ],
+          "condition": ["obs-7", "vs-2"],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "mustSupport": true,
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "sct-concept",
+              "map": "< 441742003 |Evaluation finding|"
+            },
+            {
+              "identity": "v2",
+              "map": "OBX.2, OBX.5, OBX.6"
+            },
+            {
+              "identity": "rim",
+              "map": "value"
+            },
+            {
+              "identity": "sct-attr",
+              "map": "363714003 |Interprets|"
+            }
+          ]
+        },
+        {
+          "id": "Observation.value[x]:valueQuantity.id",
+          "path": "Observation.value[x].id",
+          "representation": ["xmlAttr"],
+          "short": "Unique id for inter-element referencing",
+          "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Element.id",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                  "valueUrl": "string"
+                }
+              ],
+              "code": "http://hl7.org/fhirpath/System.String"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ]
+        },
+        {
+          "id": "Observation.value[x]:valueQuantity.extension",
+          "path": "Observation.value[x].extension",
+          "slicing": {
+            "discriminator": [
+              {
+                "type": "value",
+                "path": "url"
+              }
+            ],
+            "description": "Extensions are always sliced by (at least) url",
+            "rules": "open"
+          },
+          "short": "Additional content defined by implementations",
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "alias": ["extensions", "user content"],
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Element.extension",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            },
+            {
+              "key": "ext-1",
+              "severity": "error",
+              "human": "Must have either extensions or value[x], not both",
+              "expression": "extension.exists() != value.exists()",
+              "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+              "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ]
+        },
+        {
+          "id": "Observation.value[x]:valueQuantity.value",
+          "path": "Observation.value[x].value",
+          "short": "Numerical value (with implicit precision)",
+          "definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
+          "comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
+          "requirements": "Precision is handled implicitly in almost all cases of measurement.",
+          "min": 1,
+          "max": "1",
+          "base": {
+            "path": "Quantity.value",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "decimal"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "mustSupport": true,
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "SN.2  / CQ - N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
+            }
+          ]
+        },
+        {
+          "id": "Observation.value[x]:valueQuantity.comparator",
+          "path": "Observation.value[x].comparator",
+          "short": "< | <= | >= | > - how to understand the value",
+          "definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
+          "requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Quantity.comparator",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": true,
+          "isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
+          "isSummary": true,
+          "binding": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                "valueString": "QuantityComparator"
+              }
+            ],
+            "strength": "required",
+            "description": "How the Quantity should be understood and represented.",
+            "valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
+          },
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "SN.1  / CQ.1"
+            },
+            {
+              "identity": "rim",
+              "map": "IVL properties"
+            }
+          ]
+        },
+        {
+          "id": "Observation.value[x]:valueQuantity.unit",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+              "valueBoolean": true
+            }
+          ],
+          "path": "Observation.value[x].unit",
+          "short": "Unit representation",
+          "definition": "A human-readable form of the unit.",
+          "requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
+          "min": 1,
+          "max": "1",
+          "base": {
+            "path": "Quantity.unit",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "mustSupport": true,
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "(see OBX.6 etc.) / CQ.2"
+            },
+            {
+              "identity": "rim",
+              "map": "PQ.unit"
+            }
+          ]
+        },
+        {
+          "id": "Observation.value[x]:valueQuantity.system",
+          "path": "Observation.value[x].system",
+          "short": "System that defines coded unit form",
+          "definition": "The identification of the system that provides the coded form of the unit.",
+          "requirements": "Need to know the system that defines the coded form of the unit.",
+          "min": 1,
+          "max": "1",
+          "base": {
+            "path": "Quantity.system",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "uri"
+            }
+          ],
+          "fixedUri": "http://unitsofmeasure.org",
+          "condition": ["qty-3"],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "mustSupport": true,
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "(see OBX.6 etc.) / CQ.2"
+            },
+            {
+              "identity": "rim",
+              "map": "CO.codeSystem, PQ.translation.codeSystem"
+            }
+          ]
+        },
+        {
+          "id": "Observation.value[x]:valueQuantity.code",
+          "path": "Observation.value[x].code",
+          "short": "Coded responses from the common UCUM units for vital signs value set.",
+          "definition": "Coded responses from the common UCUM units for vital signs value set.",
+          "comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
+          "requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
+          "min": 1,
+          "max": "1",
+          "base": {
+            "path": "Quantity.code",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "fixedCode": "/min",
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "mustSupport": true,
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "(see OBX.6 etc.) / CQ.2"
+            },
+            {
+              "identity": "rim",
+              "map": "PQ.code, MO.currency, PQ.translation.code"
+            }
+          ]
+        },
+        {
+          "id": "Observation.dataAbsentReason",
+          "path": "Observation.dataAbsentReason",
+          "short": "Why the result is missing",
+          "definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
+          "comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
+          "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Observation.dataAbsentReason",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "CodeableConcept"
+            }
+          ],
+          "condition": ["obs-6", "vs-2"],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "mustSupport": true,
+          "isModifier": false,
+          "isSummary": false,
+          "binding": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                "valueString": "ObservationValueAbsentReason"
+              }
+            ],
+            "strength": "extensible",
+            "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+            "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+          },
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "value.nullFlavor"
+            }
+          ]
+        },
+        {
+          "id": "Observation.interpretation",
+          "path": "Observation.interpretation",
+          "short": "High, low, normal, etc.",
+          "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+          "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+          "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+          "alias": ["Abnormal Flag"],
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Observation.interpretation",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "CodeableConcept"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "binding": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                "valueString": "ObservationInterpretation"
+              }
+            ],
+            "strength": "extensible",
+            "description": "Codes identifying interpretations of observations.",
+            "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+          },
+          "mapping": [
+            {
+              "identity": "sct-concept",
+              "map": "< 260245000 |Findings values|"
+            },
+            {
+              "identity": "v2",
+              "map": "OBX-8"
+            },
+            {
+              "identity": "rim",
+              "map": "interpretationCode"
+            },
+            {
+              "identity": "sct-attr",
+              "map": "363713009 |Has interpretation|"
+            }
+          ]
+        },
+        {
+          "id": "Observation.note",
+          "path": "Observation.note",
+          "short": "Comments about the observation",
+          "definition": "Comments about the observation or the results.",
+          "comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
+          "requirements": "Need to be able to provide free text additional information.",
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Observation.note",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Annotation"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
+            },
+            {
+              "identity": "rim",
+              "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+            }
+          ]
+        },
+        {
+          "id": "Observation.bodySite",
+          "path": "Observation.bodySite",
+          "short": "Observed body part",
+          "definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+          "comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Observation.bodySite",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "CodeableConcept"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "binding": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                "valueString": "BodySite"
+              }
+            ],
+            "strength": "example",
+            "description": "Codes describing anatomical locations. May include laterality.",
+            "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+          },
+          "mapping": [
+            {
+              "identity": "sct-concept",
+              "map": "< 123037004 |Body structure|"
+            },
+            {
+              "identity": "v2",
+              "map": "OBX-20"
+            },
+            {
+              "identity": "rim",
+              "map": "targetSiteCode"
+            },
+            {
+              "identity": "sct-attr",
+              "map": "718497002 |Inherent location|"
+            }
+          ]
+        },
+        {
+          "id": "Observation.method",
+          "path": "Observation.method",
+          "short": "How it was done",
+          "definition": "Indicates the mechanism used to perform the observation.",
+          "comment": "Only used if not implicit in code for Observation.code.",
+          "requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Observation.method",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "CodeableConcept"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "binding": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                "valueString": "ObservationMethod"
+              }
+            ],
+            "strength": "example",
+            "description": "Methods for simple observations.",
+            "valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
+          },
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "OBX-17"
+            },
+            {
+              "identity": "rim",
+              "map": "methodCode"
+            }
+          ]
+        },
+        {
+          "id": "Observation.specimen",
+          "path": "Observation.specimen",
+          "short": "Specimen used for this observation",
+          "definition": "The specimen that was used when this observation was made.",
+          "comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Observation.specimen",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "Reference",
+              "targetProfile": [
+                "http://hl7.org/fhir/StructureDefinition/Specimen"
+              ]
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "sct-concept",
+              "map": "< 123038009 |Specimen|"
+            },
+            {
+              "identity": "v2",
+              "map": "SPM segment"
+            },
+            {
+              "identity": "rim",
+              "map": "participation[typeCode=SPC].specimen"
+            },
+            {
+              "identity": "sct-attr",
+              "map": "704319004 |Inherent in|"
+            }
+          ]
+        },
+        {
+          "id": "Observation.device",
+          "path": "Observation.device",
+          "short": "(Measurement) Device",
+          "definition": "The device used to generate the observation data.",
+          "comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Observation.device",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "Reference",
+              "targetProfile": [
+                "http://hl7.org/fhir/StructureDefinition/Device",
+                "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
+              ]
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "sct-concept",
+              "map": "< 49062001 |Device|"
+            },
+            {
+              "identity": "v2",
+              "map": "OBX-17 / PRT -10"
+            },
+            {
+              "identity": "rim",
+              "map": "participation[typeCode=DEV]"
+            },
+            {
+              "identity": "sct-attr",
+              "map": "424226004 |Using device|"
+            }
+          ]
+        },
+        {
+          "id": "Observation.referenceRange",
+          "path": "Observation.referenceRange",
+          "short": "Provides guide for interpretation",
+          "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
+          "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+          "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Observation.referenceRange",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "BackboneElement"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            },
+            {
+              "key": "obs-3",
+              "severity": "error",
+              "human": "Must have at least a low or a high or text",
+              "expression": "low.exists() or high.exists() or text.exists()",
+              "xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "OBX.7"
+            },
+            {
+              "identity": "rim",
+              "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+            }
+          ]
+        },
+        {
+          "id": "Observation.referenceRange.id",
+          "path": "Observation.referenceRange.id",
+          "representation": ["xmlAttr"],
+          "short": "Unique id for inter-element referencing",
+          "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Element.id",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                  "valueUrl": "string"
+                }
+              ],
+              "code": "http://hl7.org/fhirpath/System.String"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ]
+        },
+        {
+          "id": "Observation.referenceRange.extension",
+          "path": "Observation.referenceRange.extension",
+          "short": "Additional content defined by implementations",
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "alias": ["extensions", "user content"],
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Element.extension",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            },
+            {
+              "key": "ext-1",
+              "severity": "error",
+              "human": "Must have either extensions or value[x], not both",
+              "expression": "extension.exists() != value.exists()",
+              "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+              "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ]
+        },
+        {
+          "id": "Observation.referenceRange.modifierExtension",
+          "path": "Observation.referenceRange.modifierExtension",
+          "short": "Extensions that cannot be ignored even if unrecognized",
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+          "alias": ["extensions", "user content", "modifiers"],
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "BackboneElement.modifierExtension",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            },
+            {
+              "key": "ext-1",
+              "severity": "error",
+              "human": "Must have either extensions or value[x], not both",
+              "expression": "extension.exists() != value.exists()",
+              "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+              "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+            }
+          ],
+          "isModifier": true,
+          "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            }
+          ]
+        },
+        {
+          "id": "Observation.referenceRange.low",
+          "path": "Observation.referenceRange.low",
+          "short": "Low Range, if relevant",
+          "definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Observation.referenceRange.low",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "Quantity",
+              "profile": [
+                "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+              ]
+            }
+          ],
+          "condition": ["obs-3"],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "OBX-7"
+            },
+            {
+              "identity": "rim",
+              "map": "value:IVL_PQ.low"
+            }
+          ]
+        },
+        {
+          "id": "Observation.referenceRange.high",
+          "path": "Observation.referenceRange.high",
+          "short": "High Range, if relevant",
+          "definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Observation.referenceRange.high",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "Quantity",
+              "profile": [
+                "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+              ]
+            }
+          ],
+          "condition": ["obs-3"],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "OBX-7"
+            },
+            {
+              "identity": "rim",
+              "map": "value:IVL_PQ.high"
+            }
+          ]
+        },
+        {
+          "id": "Observation.referenceRange.type",
+          "path": "Observation.referenceRange.type",
+          "short": "Reference range qualifier",
+          "definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
+          "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
+          "requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Observation.referenceRange.type",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "CodeableConcept"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "binding": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                "valueString": "ObservationRangeMeaning"
+              }
+            ],
+            "strength": "preferred",
+            "description": "Code for the meaning of a reference range.",
+            "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
+          },
+          "mapping": [
+            {
+              "identity": "sct-concept",
+              "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+            },
+            {
+              "identity": "v2",
+              "map": "OBX-10"
+            },
+            {
+              "identity": "rim",
+              "map": "interpretationCode"
+            }
+          ]
+        },
+        {
+          "id": "Observation.referenceRange.appliesTo",
+          "path": "Observation.referenceRange.appliesTo",
+          "short": "Reference range population",
+          "definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
+          "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
+          "requirements": "Need to be able to identify the target population for proper interpretation.",
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Observation.referenceRange.appliesTo",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "CodeableConcept"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "binding": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                "valueString": "ObservationRangeType"
+              }
+            ],
+            "strength": "example",
+            "description": "Codes identifying the population the reference range applies to.",
+            "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
+          },
+          "mapping": [
+            {
+              "identity": "sct-concept",
+              "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+            },
+            {
+              "identity": "v2",
+              "map": "OBX-10"
+            },
+            {
+              "identity": "rim",
+              "map": "interpretationCode"
+            }
+          ]
+        },
+        {
+          "id": "Observation.referenceRange.age",
+          "path": "Observation.referenceRange.age",
+          "short": "Applicable age range, if relevant",
+          "definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
+          "requirements": "Some analytes vary greatly over age.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Observation.referenceRange.age",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "Range"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
+            }
+          ]
+        },
+        {
+          "id": "Observation.referenceRange.text",
+          "path": "Observation.referenceRange.text",
+          "short": "Text based reference range in an observation",
+          "definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Observation.referenceRange.text",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "OBX-7"
+            },
+            {
+              "identity": "rim",
+              "map": "value:ST"
+            }
+          ]
+        },
+        {
+          "id": "Observation.hasMember",
+          "path": "Observation.hasMember",
+          "short": "Used when reporting vital signs panel components",
+          "definition": "Used when reporting vital signs panel components.",
+          "comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Observation.hasMember",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Reference",
+              "targetProfile": [
+                "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+              ]
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "Relationships established by OBX-4 usage"
+            },
+            {
+              "identity": "rim",
+              "map": "outBoundRelationship"
+            }
+          ]
+        },
+        {
+          "id": "Observation.derivedFrom",
+          "path": "Observation.derivedFrom",
+          "short": "Related measurements the observation is made from",
+          "definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
+          "comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Observation.derivedFrom",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Reference",
+              "targetProfile": [
+                "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+                "http://hl7.org/fhir/StructureDefinition/ImagingStudy",
+                "http://hl7.org/fhir/StructureDefinition/Media",
+                "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+              ]
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "Relationships established by OBX-4 usage"
+            },
+            {
+              "identity": "rim",
+              "map": ".targetObservation"
+            }
+          ]
+        },
+        {
+          "id": "Observation.component",
+          "path": "Observation.component",
+          "short": "Used when reporting systolic and diastolic blood pressure.",
+          "definition": "Used when reporting systolic and diastolic blood pressure.",
+          "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+          "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Observation.component",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "BackboneElement"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            },
+            {
+              "key": "vs-3",
+              "severity": "error",
+              "human": "If there is no a value a data absent reason must be present",
+              "expression": "value.exists() or dataAbsentReason.exists()",
+              "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason"
+            }
+          ],
+          "mustSupport": true,
+          "isModifier": false,
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "containment by OBX-4?"
+            },
+            {
+              "identity": "rim",
+              "map": "outBoundRelationship[typeCode=COMP]"
+            }
+          ]
+        },
+        {
+          "id": "Observation.component.id",
+          "path": "Observation.component.id",
+          "representation": ["xmlAttr"],
+          "short": "Unique id for inter-element referencing",
+          "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Element.id",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                  "valueUrl": "string"
+                }
+              ],
+              "code": "http://hl7.org/fhirpath/System.String"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ]
+        },
+        {
+          "id": "Observation.component.extension",
+          "path": "Observation.component.extension",
+          "short": "Additional content defined by implementations",
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "alias": ["extensions", "user content"],
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Element.extension",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            },
+            {
+              "key": "ext-1",
+              "severity": "error",
+              "human": "Must have either extensions or value[x], not both",
+              "expression": "extension.exists() != value.exists()",
+              "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+              "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "n/a"
+            }
+          ]
+        },
+        {
+          "id": "Observation.component.modifierExtension",
+          "path": "Observation.component.modifierExtension",
+          "short": "Extensions that cannot be ignored even if unrecognized",
+          "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+          "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+          "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+          "alias": ["extensions", "user content", "modifiers"],
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "BackboneElement.modifierExtension",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            },
+            {
+              "key": "ext-1",
+              "severity": "error",
+              "human": "Must have either extensions or value[x], not both",
+              "expression": "extension.exists() != value.exists()",
+              "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+              "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+            }
+          ],
+          "isModifier": true,
+          "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+          "isSummary": true,
+          "mapping": [
+            {
+              "identity": "rim",
+              "map": "N/A"
+            }
+          ]
+        },
+        {
+          "id": "Observation.component.code",
+          "path": "Observation.component.code",
+          "short": "Type of component observation (code / type)",
+          "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+          "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+          "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+          "min": 1,
+          "max": "1",
+          "base": {
+            "path": "Observation.component.code",
+            "min": 1,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "CodeableConcept"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "mustSupport": true,
+          "isModifier": false,
+          "isSummary": true,
+          "binding": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                "valueString": "VitalSigns"
+              }
+            ],
+            "strength": "extensible",
+            "description": "This identifies the vital sign result type.",
+            "valueSet": "http://hl7.org/fhir/ValueSet/observation-vitalsignresult"
+          },
+          "mapping": [
+            {
+              "identity": "w5",
+              "map": "FiveWs.what[x]"
+            },
+            {
+              "identity": "sct-concept",
+              "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+            },
+            {
+              "identity": "v2",
+              "map": "OBX-3"
+            },
+            {
+              "identity": "rim",
+              "map": "code"
+            }
+          ]
+        },
+        {
+          "id": "Observation.component.value[x]",
+          "path": "Observation.component.value[x]",
+          "short": "Vital Sign Value recorded with UCUM",
+          "definition": "Vital Sign Value recorded with UCUM.",
+          "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+          "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Observation.component.value[x]",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "Quantity"
+            },
+            {
+              "code": "CodeableConcept"
+            },
+            {
+              "code": "string"
+            },
+            {
+              "code": "boolean"
+            },
+            {
+              "code": "integer"
+            },
+            {
+              "code": "Range"
+            },
+            {
+              "code": "Ratio"
+            },
+            {
+              "code": "SampledData"
+            },
+            {
+              "code": "time"
+            },
+            {
+              "code": "dateTime"
+            },
+            {
+              "code": "Period"
+            }
+          ],
+          "condition": ["vs-3"],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "mustSupport": true,
+          "isModifier": false,
+          "isSummary": true,
+          "binding": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                "valueString": "VitalSignsUnits"
+              }
+            ],
+            "strength": "required",
+            "description": "Common UCUM units for recording Vital Signs.",
+            "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+          },
+          "mapping": [
+            {
+              "identity": "sct-concept",
+              "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+            },
+            {
+              "identity": "v2",
+              "map": "OBX.2, OBX.5, OBX.6"
+            },
+            {
+              "identity": "rim",
+              "map": "value"
+            },
+            {
+              "identity": "sct-attr",
+              "map": "363714003 |Interprets|"
+            }
+          ]
+        },
+        {
+          "id": "Observation.component.dataAbsentReason",
+          "path": "Observation.component.dataAbsentReason",
+          "short": "Why the component result is missing",
+          "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+          "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+          "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Observation.component.dataAbsentReason",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "CodeableConcept"
+            }
+          ],
+          "condition": ["obs-6", "vs-3"],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "mustSupport": true,
+          "isModifier": false,
+          "isSummary": false,
+          "binding": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                "valueString": "ObservationValueAbsentReason"
+              }
+            ],
+            "strength": "extensible",
+            "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+            "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+          },
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "N/A"
+            },
+            {
+              "identity": "rim",
+              "map": "value.nullFlavor"
+            }
+          ]
+        },
+        {
+          "id": "Observation.component.interpretation",
+          "path": "Observation.component.interpretation",
+          "short": "High, low, normal, etc.",
+          "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+          "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+          "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+          "alias": ["Abnormal Flag"],
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Observation.component.interpretation",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "CodeableConcept"
+            }
+          ],
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "binding": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                "valueString": "ObservationInterpretation"
+              }
+            ],
+            "strength": "extensible",
+            "description": "Codes identifying interpretations of observations.",
+            "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+          },
+          "mapping": [
+            {
+              "identity": "sct-concept",
+              "map": "< 260245000 |Findings values|"
+            },
+            {
+              "identity": "v2",
+              "map": "OBX-8"
+            },
+            {
+              "identity": "rim",
+              "map": "interpretationCode"
+            },
+            {
+              "identity": "sct-attr",
+              "map": "363713009 |Has interpretation|"
+            }
+          ]
+        },
+        {
+          "id": "Observation.component.referenceRange",
+          "path": "Observation.component.referenceRange",
+          "short": "Provides guide for interpretation of component result",
+          "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+          "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+          "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Observation.component.referenceRange",
+            "min": 0,
+            "max": "*"
+          },
+          "contentReference": "#Observation.referenceRange",
+          "constraint": [
+            {
+              "key": "ele-1",
+              "severity": "error",
+              "human": "All FHIR elements must have a @value or children",
+              "expression": "hasValue() or (children().count() > id.count())",
+              "xpath": "@value|f:*|h:div",
+              "source": "http://hl7.org/fhir/StructureDefinition/Element"
+            }
+          ],
+          "isModifier": false,
+          "isSummary": false,
+          "mapping": [
+            {
+              "identity": "v2",
+              "map": "OBX.7"
+            },
+            {
+              "identity": "rim",
+              "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+            }
+          ]
+        }
+      ]
+    },
+    "differential": {
+      "element": [
+        {
+          "id": "Observation",
+          "path": "Observation",
+          "short": "FHIR Heart Rate Profile",
+          "definition": "This profile defines how to represent heart rate observations in FHIR using a standard LOINC code and UCUM units of measure.",
+          "min": 0,
+          "max": "*"
+        },
+        {
+          "id": "Observation.code",
+          "path": "Observation.code",
+          "short": "Heart Rate",
+          "definition": "Heart Rate.",
+          "comment": "additional codes that translate or map to this code are allowed.  For example a more granular LOINC code or code that is used locally in a system.",
+          "alias": ["Test", "Name"]
+        },
+        {
+          "id": "Observation.code.coding",
+          "path": "Observation.code.coding",
+          "slicing": {
+            "discriminator": [
+              {
+                "type": "value",
+                "path": "code"
+              },
+              {
+                "type": "value",
+                "path": "system"
+              }
+            ],
+            "ordered": false,
+            "rules": "open"
+          }
+        },
+        {
+          "id": "Observation.code.coding:HeartRateCode",
+          "path": "Observation.code.coding",
+          "sliceName": "HeartRateCode",
+          "min": 1,
+          "max": "1"
+        },
+        {
+          "id": "Observation.code.coding:HeartRateCode.system",
+          "path": "Observation.code.coding.system",
+          "min": 1,
+          "max": "1",
+          "type": [
+            {
+              "code": "uri"
+            }
+          ],
+          "fixedUri": "http://loinc.org"
+        },
+        {
+          "id": "Observation.code.coding:HeartRateCode.code",
+          "path": "Observation.code.coding.code",
+          "min": 1,
+          "max": "1",
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "fixedCode": "8867-4"
+        },
+        {
+          "id": "Observation.valueQuantity",
+          "path": "Observation.valueQuantity"
+        },
+        {
+          "id": "Observation.valueQuantity.value",
+          "path": "Observation.valueQuantity.value",
+          "min": 1,
+          "max": "1",
+          "type": [
+            {
+              "code": "decimal"
+            }
+          ],
+          "mustSupport": true
+        },
+        {
+          "id": "Observation.valueQuantity.unit",
+          "path": "Observation.valueQuantity.unit",
+          "min": 1,
+          "max": "1",
+          "type": [
+            {
+              "code": "string"
+            }
+          ],
+          "mustSupport": true
+        },
+        {
+          "id": "Observation.valueQuantity.system",
+          "path": "Observation.valueQuantity.system",
+          "min": 1,
+          "max": "1",
+          "type": [
+            {
+              "code": "uri"
+            }
+          ],
+          "fixedUri": "http://unitsofmeasure.org",
+          "mustSupport": true
+        },
+        {
+          "id": "Observation.valueQuantity.code",
+          "path": "Observation.valueQuantity.code",
+          "short": "Coded responses from the common UCUM units for vital signs value set.",
+          "definition": "Coded responses from the common UCUM units for vital signs value set.",
+          "min": 1,
+          "max": "1",
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "fixedCode": "/min",
+          "mustSupport": true
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/mockDefinition.json
+++ b/tests/fixtures/mockDefinition.json
@@ -1,0 +1,135 @@
+{
+  "fullUrl": "http://hl7.org/fhir/StructureDefinition/mock",
+  "resource": {
+    "resourceType": "StructureDefinition",
+    "id": "mock",
+    "url": "http://hl7.org/fhir/StructureDefinition/mock",
+    "version": "4.0.1",
+    "name": "Mock",
+    "title": "Mock Profile",
+    "date": "2018-08-11",
+    "publisher": "Arkhn dev team",
+    "description": "FHIR Heart Rate Profile",
+    "fhirVersion": "4.0.1",
+    "kind": "resource",
+    "type": "Mock",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/super-mock",
+    "derivation": "constraint",
+    "snapshot": {
+      "element": [
+        {
+          "id": "Mock",
+          "path": "Mock",
+          "min": 0,
+          "max": "1",
+          "constraint": [
+            {
+              "key": "dom-2",
+              "severity": "error",
+              "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+              "expression": "contained.contained.empty()",
+              "xpath": "not(parent::f:contained and f:contained)",
+              "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+            }
+          ]
+        },
+        {
+          "id": "Mock.a",
+          "path": "Mock.a",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Resource.id",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "string"
+            }
+          ]
+        },
+        {
+          "id": "Mock.a.b",
+          "path": "Mock.a.b",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Resource.id",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "string"
+            }
+          ]
+        },
+        {
+          "id": "Mock.a.b.c",
+          "path": "Mock.a.b.c",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Resource.id",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "string"
+            }
+          ]
+        },
+        {
+          "id": "Mock.a.d",
+          "path": "Mock.a.d",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Resource.id",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "string"
+            }
+          ]
+        },
+        {
+          "id": "Mock.e",
+          "path": "Mock.e",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Resource.id",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "string"
+            }
+          ]
+        },
+        {
+          "id": "Mock.e.f",
+          "path": "Mock.e.f",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Resource.id",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "string"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
     // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+    "resolveJsonModule": true,
 
     /* Strict Type-Checking Options */
     "strict": true /* Enable all strict type-checking options. */,
@@ -40,7 +41,7 @@
 
     /* Module Resolution Options */
     // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    "baseUrl": "src",
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
@@ -63,5 +64,5 @@
     /* Advanced Options */
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "tests/definition.test.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1494,6 +1494,11 @@ compare-func@^1.3.1:
     array-ify "^1.0.0"
     dot-prop "^3.0.0"
 
+compare-versions@^3.5.1:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"
+  integrity sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
+
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
@@ -2422,7 +2427,7 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-find-versions@^3.0.0:
+find-versions@^3.0.0, find-versions@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/find-versions/-/find-versions-3.2.0.tgz#10297f98030a786829681690545ef659ed1d254e"
   integrity sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==
@@ -2894,6 +2899,22 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
+husky@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-4.2.3.tgz#3b18d2ee5febe99e27f2983500202daffbc3151e"
+  integrity sha512-VxTsSTRwYveKXN4SaH1/FefRJYCtx+wx04sSVcOpD7N2zjoHxa+cEJ07Qg5NmV3HAK+IRKOyNVpi2YBIVccIfQ==
+  dependencies:
+    chalk "^3.0.0"
+    ci-info "^2.0.0"
+    compare-versions "^3.5.1"
+    cosmiconfig "^6.0.0"
+    find-versions "^3.2.0"
+    opencollective-postinstall "^2.0.2"
+    pkg-dir "^4.2.0"
+    please-upgrade-node "^3.2.0"
+    slash "^3.0.0"
+    which-pm-runs "^1.0.0"
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -3158,6 +3179,11 @@ is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
+
+is-file@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-file/-/is-file-1.0.0.tgz#28a44cfbd9d3db193045f22b65fce8edf9620596"
+  integrity sha1-KKRM+9nT2xkwRfIrZfzo7fliBZY=
 
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
@@ -5024,6 +5050,11 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
+opencollective-postinstall@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
+  integrity sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==
+
 opener@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
@@ -5385,6 +5416,13 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+please-upgrade-node@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
+  integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
+  dependencies:
+    semver-compare "^1.0.0"
 
 pn@^1.1.0:
   version "1.1.0"
@@ -6046,6 +6084,11 @@ semantic-release@^17.0.4:
     semver-diff "^3.1.1"
     signale "^1.2.1"
     yargs "^15.0.1"
+
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
 semver-diff@^2.0.0:
   version "2.1.0"
@@ -7057,6 +7100,15 @@ v8-to-istanbul@^4.0.1:
     convert-source-map "^1.6.0"
     source-map "^0.7.3"
 
+validate-commit@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/validate-commit/-/validate-commit-3.4.0.tgz#bc843c0b563e2e3bac806e7466f7502abc17dc38"
+  integrity sha512-v63luZ4YLoH68xAvd/cgalyMT+au+I75itAnP9te7eR/PiaqptH366iz3Gmc7NWBC9/fFfoVsI7m8MYqDvoJBw==
+  dependencies:
+    chalk "^2.0.0"
+    is-file "^1.0.0"
+    yargs "^10.0.3"
+
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
@@ -7141,6 +7193,11 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
+
+which-pm-runs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
+  integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
 
 which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"
@@ -7324,12 +7381,37 @@ yargs-parser@^7.0.0:
   dependencies:
     camelcase "^4.1.0"
 
+yargs-parser@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
+  integrity sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==
+  dependencies:
+    camelcase "^4.1.0"
+
 yargs-parser@^9.0.2:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
   integrity sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=
   dependencies:
     camelcase "^4.1.0"
+
+yargs@^10.0.3:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.1.2.tgz#454d074c2b16a51a43e2fb7807e4f9de69ccb5c5"
+  integrity sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^8.1.0"
 
 yargs@^11.0.0:
   version "11.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,80 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.0.0":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
   integrity sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
   dependencies:
     "@babel/highlight" "^7.8.3"
+
+"@babel/core@^7.1.0", "@babel/core@^7.7.5":
+  version "7.8.7"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.8.7.tgz#b69017d221ccdeb203145ae9da269d72cf102f3b"
+  integrity sha512-rBlqF3Yko9cynC5CCFy6+K/w2N+Sq/ff2BPy+Krp7rHlABIr5epbA7OxVeKoMHB39LZOp1UY5SuLjy6uWi35yA==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.8.7"
+    "@babel/helpers" "^7.8.4"
+    "@babel/parser" "^7.8.7"
+    "@babel/template" "^7.8.6"
+    "@babel/traverse" "^7.8.6"
+    "@babel/types" "^7.8.7"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.1"
+    json5 "^2.1.0"
+    lodash "^4.17.13"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.8.6", "@babel/generator@^7.8.7":
+  version "7.8.8"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.8.8.tgz#cdcd58caab730834cee9eeadb729e833b625da3e"
+  integrity sha512-HKyUVu69cZoclptr8t8U5b6sx6zoWjh8jiUhnuj3MpZuKT2dJ8zPTuiy31luq32swhI0SpwItCIlU8XW7BZeJg==
+  dependencies:
+    "@babel/types" "^7.8.7"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+
+"@babel/helper-function-name@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz#eeeb665a01b1f11068e9fb86ad56a1cb1a824cca"
+  integrity sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.8.3"
+    "@babel/template" "^7.8.3"
+    "@babel/types" "^7.8.3"
+
+"@babel/helper-get-function-arity@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz#b894b947bd004381ce63ea1db9f08547e920abd5"
+  integrity sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==
+  dependencies:
+    "@babel/types" "^7.8.3"
+
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.8.0":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz#9ea293be19babc0f52ff8ca88b34c3611b208670"
+  integrity sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==
+
+"@babel/helper-split-export-declaration@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz#31a9f30070f91368a7182cf05f831781065fc7a9"
+  integrity sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
+  dependencies:
+    "@babel/types" "^7.8.3"
+
+"@babel/helpers@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.8.4.tgz#754eb3ee727c165e0a240d6c207de7c455f36f73"
+  integrity sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==
+  dependencies:
+    "@babel/template" "^7.8.3"
+    "@babel/traverse" "^7.8.4"
+    "@babel/types" "^7.8.3"
 
 "@babel/highlight@^7.8.3":
   version "7.8.3"
@@ -18,12 +86,77 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@babel/parser@^7.1.0", "@babel/parser@^7.7.5", "@babel/parser@^7.8.6", "@babel/parser@^7.8.7":
+  version "7.8.8"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.8.tgz#4c3b7ce36db37e0629be1f0d50a571d2f86f6cd4"
+  integrity sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA==
+
+"@babel/plugin-syntax-bigint@^7.0.0":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz#4c9a6f669f5d0cdf1b90a1671e9a146be5300cea"
+  integrity sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-object-rest-spread@^7.0.0":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz#60e225edcbd98a640332a2e72dd3e66f1af55871"
+  integrity sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
 "@babel/runtime@^7.8.7":
   version "7.8.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.7.tgz#8fefce9802db54881ba59f90bb28719b4996324d"
   integrity sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==
   dependencies:
     regenerator-runtime "^0.13.4"
+
+"@babel/template@^7.7.4", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
+  version "7.8.6"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.6.tgz#86b22af15f828dfb086474f964dcc3e39c43ce2b"
+  integrity sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/parser" "^7.8.6"
+    "@babel/types" "^7.8.6"
+
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.7.4", "@babel/traverse@^7.8.4", "@babel/traverse@^7.8.6":
+  version "7.8.6"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.8.6.tgz#acfe0c64e1cd991b3e32eae813a6eb564954b5ff"
+  integrity sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.8.6"
+    "@babel/helper-function-name" "^7.8.3"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+    "@babel/parser" "^7.8.6"
+    "@babel/types" "^7.8.6"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
+"@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.8.7":
+  version "7.8.7"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.8.7.tgz#1fc9729e1acbb2337d5b6977a63979b4819f5d1d"
+  integrity sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@bcoe/v8-coverage@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
+  integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
+
+"@cnakazawa/watch@^1.0.3":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
+  integrity sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==
+  dependencies:
+    exec-sh "^0.3.2"
+    minimist "^1.2.0"
 
 "@iarna/cli@^1.2.0":
   version "1.2.0"
@@ -33,6 +166,180 @@
     signal-exit "^3.0.2"
     update-notifier "^2.2.0"
     yargs "^8.0.2"
+
+"@istanbuljs/load-nyc-config@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz#10602de5570baea82f8afbfa2630b24e7a8cfe5b"
+  integrity sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==
+  dependencies:
+    camelcase "^5.3.1"
+    find-up "^4.1.0"
+    js-yaml "^3.13.1"
+    resolve-from "^5.0.0"
+
+"@istanbuljs/schema@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
+  integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
+
+"@jest/console@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-25.1.0.tgz#1fc765d44a1e11aec5029c08e798246bd37075ab"
+  integrity sha512-3P1DpqAMK/L07ag/Y9/Jup5iDEG9P4pRAuZiMQnU0JB3UOvCyYCjCoxr7sIA80SeyUCUKrr24fKAxVpmBgQonA==
+  dependencies:
+    "@jest/source-map" "^25.1.0"
+    chalk "^3.0.0"
+    jest-util "^25.1.0"
+    slash "^3.0.0"
+
+"@jest/core@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-25.1.0.tgz#3d4634fc3348bb2d7532915d67781cdac0869e47"
+  integrity sha512-iz05+NmwCmZRzMXvMo6KFipW7nzhbpEawrKrkkdJzgytavPse0biEnCNr2wRlyCsp3SmKaEY+SGv7YWYQnIdig==
+  dependencies:
+    "@jest/console" "^25.1.0"
+    "@jest/reporters" "^25.1.0"
+    "@jest/test-result" "^25.1.0"
+    "@jest/transform" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    ansi-escapes "^4.2.1"
+    chalk "^3.0.0"
+    exit "^0.1.2"
+    graceful-fs "^4.2.3"
+    jest-changed-files "^25.1.0"
+    jest-config "^25.1.0"
+    jest-haste-map "^25.1.0"
+    jest-message-util "^25.1.0"
+    jest-regex-util "^25.1.0"
+    jest-resolve "^25.1.0"
+    jest-resolve-dependencies "^25.1.0"
+    jest-runner "^25.1.0"
+    jest-runtime "^25.1.0"
+    jest-snapshot "^25.1.0"
+    jest-util "^25.1.0"
+    jest-validate "^25.1.0"
+    jest-watcher "^25.1.0"
+    micromatch "^4.0.2"
+    p-each-series "^2.1.0"
+    realpath-native "^1.1.0"
+    rimraf "^3.0.0"
+    slash "^3.0.0"
+    strip-ansi "^6.0.0"
+
+"@jest/environment@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-25.1.0.tgz#4a97f64770c9d075f5d2b662b5169207f0a3f787"
+  integrity sha512-cTpUtsjU4cum53VqBDlcW0E4KbQF03Cn0jckGPW/5rrE9tb+porD3+hhLtHAwhthsqfyF+bizyodTlsRA++sHg==
+  dependencies:
+    "@jest/fake-timers" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    jest-mock "^25.1.0"
+
+"@jest/fake-timers@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-25.1.0.tgz#a1e0eff51ffdbb13ee81f35b52e0c1c11a350ce8"
+  integrity sha512-Eu3dysBzSAO1lD7cylZd/CVKdZZ1/43SF35iYBNV1Lvvn2Undp3Grwsv8PrzvbLhqwRzDd4zxrY4gsiHc+wygQ==
+  dependencies:
+    "@jest/types" "^25.1.0"
+    jest-message-util "^25.1.0"
+    jest-mock "^25.1.0"
+    jest-util "^25.1.0"
+    lolex "^5.0.0"
+
+"@jest/reporters@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-25.1.0.tgz#9178ecf136c48f125674ac328f82ddea46e482b0"
+  integrity sha512-ORLT7hq2acJQa8N+NKfs68ZtHFnJPxsGqmofxW7v7urVhzJvpKZG9M7FAcgh9Ee1ZbCteMrirHA3m5JfBtAaDg==
+  dependencies:
+    "@bcoe/v8-coverage" "^0.2.3"
+    "@jest/console" "^25.1.0"
+    "@jest/environment" "^25.1.0"
+    "@jest/test-result" "^25.1.0"
+    "@jest/transform" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    chalk "^3.0.0"
+    collect-v8-coverage "^1.0.0"
+    exit "^0.1.2"
+    glob "^7.1.2"
+    istanbul-lib-coverage "^3.0.0"
+    istanbul-lib-instrument "^4.0.0"
+    istanbul-lib-report "^3.0.0"
+    istanbul-lib-source-maps "^4.0.0"
+    istanbul-reports "^3.0.0"
+    jest-haste-map "^25.1.0"
+    jest-resolve "^25.1.0"
+    jest-runtime "^25.1.0"
+    jest-util "^25.1.0"
+    jest-worker "^25.1.0"
+    slash "^3.0.0"
+    source-map "^0.6.0"
+    string-length "^3.1.0"
+    terminal-link "^2.0.0"
+    v8-to-istanbul "^4.0.1"
+  optionalDependencies:
+    node-notifier "^6.0.0"
+
+"@jest/source-map@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-25.1.0.tgz#b012e6c469ccdbc379413f5c1b1ffb7ba7034fb0"
+  integrity sha512-ohf2iKT0xnLWcIUhL6U6QN+CwFWf9XnrM2a6ybL9NXxJjgYijjLSitkYHIdzkd8wFliH73qj/+epIpTiWjRtAA==
+  dependencies:
+    callsites "^3.0.0"
+    graceful-fs "^4.2.3"
+    source-map "^0.6.0"
+
+"@jest/test-result@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-25.1.0.tgz#847af2972c1df9822a8200457e64be4ff62821f7"
+  integrity sha512-FZzSo36h++U93vNWZ0KgvlNuZ9pnDnztvaM7P/UcTx87aPDotG18bXifkf1Ji44B7k/eIatmMzkBapnAzjkJkg==
+  dependencies:
+    "@jest/console" "^25.1.0"
+    "@jest/transform" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    collect-v8-coverage "^1.0.0"
+
+"@jest/test-sequencer@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-25.1.0.tgz#4df47208542f0065f356fcdb80026e3c042851ab"
+  integrity sha512-WgZLRgVr2b4l/7ED1J1RJQBOharxS11EFhmwDqknpknE0Pm87HLZVS2Asuuw+HQdfQvm2aXL2FvvBLxOD1D0iw==
+  dependencies:
+    "@jest/test-result" "^25.1.0"
+    jest-haste-map "^25.1.0"
+    jest-runner "^25.1.0"
+    jest-runtime "^25.1.0"
+
+"@jest/transform@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-25.1.0.tgz#221f354f512b4628d88ce776d5b9e601028ea9da"
+  integrity sha512-4ktrQ2TPREVeM+KxB4zskAT84SnmG1vaz4S+51aTefyqn3zocZUnliLLm5Fsl85I3p/kFPN4CRp1RElIfXGegQ==
+  dependencies:
+    "@babel/core" "^7.1.0"
+    "@jest/types" "^25.1.0"
+    babel-plugin-istanbul "^6.0.0"
+    chalk "^3.0.0"
+    convert-source-map "^1.4.0"
+    fast-json-stable-stringify "^2.0.0"
+    graceful-fs "^4.2.3"
+    jest-haste-map "^25.1.0"
+    jest-regex-util "^25.1.0"
+    jest-util "^25.1.0"
+    micromatch "^4.0.2"
+    pirates "^4.0.1"
+    realpath-native "^1.1.0"
+    slash "^3.0.0"
+    source-map "^0.6.1"
+    write-file-atomic "^3.0.0"
+
+"@jest/types@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.1.0.tgz#b26831916f0d7c381e11dbb5e103a72aed1b4395"
+  integrity sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^1.1.1"
+    "@types/yargs" "^15.0.0"
+    chalk "^3.0.0"
 
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
@@ -227,10 +534,50 @@
     lodash "^4.17.4"
     read-pkg-up "^7.0.0"
 
+"@sinonjs/commons@^1.7.0":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.1.tgz#da5fd19a5f71177a53778073978873964f49acf1"
+  integrity sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==
+  dependencies:
+    type-detect "4.0.8"
+
 "@tootallnate/once@1":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.0.0.tgz#9c13c2574c92d4503b005feca8f2e16cc1611506"
   integrity sha512-KYyTT/T6ALPkIRd2Ge080X/BsXvy9O0hcWTtMWkPvwAwF99+vn6Dv4GzrFT/Nn1LePr+FFDbRXXlqmsy9lw2zA==
+
+"@types/babel__core@^7.1.0":
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.6.tgz#16ff42a5ae203c9af1c6e190ed1f30f83207b610"
+  integrity sha512-tTnhWszAqvXnhW7m5jQU9PomXSiKXk2sFxpahXvI20SZKu9ylPi8WtIxueZ6ehDWikPT0jeFujMj3X4ZHuf3Tg==
+  dependencies:
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+    "@types/babel__generator" "*"
+    "@types/babel__template" "*"
+    "@types/babel__traverse" "*"
+
+"@types/babel__generator@*":
+  version "7.6.1"
+  resolved "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.6.1.tgz#4901767b397e8711aeb99df8d396d7ba7b7f0e04"
+  integrity sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@types/babel__template@*":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.0.2.tgz#4ff63d6b52eddac1de7b975a5223ed32ecea9307"
+  integrity sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==
+  dependencies:
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@types/babel__traverse@*", "@types/babel__traverse@^7.0.6":
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.0.9.tgz#be82fab304b141c3eee81a4ce3b034d0eba1590a"
+  integrity sha512-jEFQ8L1tuvPjOI8lnpaf73oCJe+aoxL6ygqSy6c8LcW98zaC+4mzWuQIRCEvKeCOu+lbqdXcg4Uqmm1S8AP1tw==
+  dependencies:
+    "@babel/types" "^7.3.0"
 
 "@types/color-name@^1.1.1":
   version "1.1.1"
@@ -241,6 +588,34 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
+"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
+  integrity sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==
+
+"@types/istanbul-lib-report@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz#c14c24f18ea8190c118ee7562b7ff99a36552686"
+  integrity sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+
+"@types/istanbul-reports@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz#7a8cbf6a406f36c8add871625b278eaf0b0d255a"
+  integrity sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+    "@types/istanbul-lib-report" "*"
+
+"@types/jest@^25.1.4":
+  version "25.1.4"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-25.1.4.tgz#9e9f1e59dda86d3fd56afce71d1ea1b331f6f760"
+  integrity sha512-QDDY2uNAhCV7TMCITrxz+MRk1EizcsevzfeS6LykIlq2V1E5oO4wXG8V2ZEd9w7Snxeeagk46YbMgZ8ESHx3sw==
+  dependencies:
+    jest-diff "^25.1.0"
+    pretty-format "^25.1.0"
 
 "@types/json-schema@^7.0.3":
   version "7.0.4"
@@ -266,6 +641,23 @@
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
   integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
+
+"@types/stack-utils@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
+  integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/yargs-parser@*":
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
+  integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
+
+"@types/yargs@^15.0.0":
+  version "15.0.4"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.4.tgz#7e5d0f8ca25e9d5849f2ea443cf7c402decd8299"
+  integrity sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==
+  dependencies:
+    "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin@^2.24.0":
   version "2.24.0"
@@ -318,17 +710,40 @@ JSONStream@^1.0.4, JSONStream@^1.3.4, JSONStream@^1.3.5:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
+abab@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"
+  integrity sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==
+
 abbrev@1, abbrev@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
+acorn-globals@^4.3.2:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.4.tgz#9fa1926addc11c97308c4e66d7add0d40c3272e7"
+  integrity sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==
+  dependencies:
+    acorn "^6.0.1"
+    acorn-walk "^6.0.1"
 
 acorn-jsx@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.2.0.tgz#4c66069173d6fdd68ed85239fc256226182b2ebe"
   integrity sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==
 
-acorn@^7.1.1:
+acorn-walk@^6.0.1:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.2.0.tgz#123cb8f3b84c2171f1f7fb252615b1c78a6b1a8c"
+  integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
+
+acorn@^6.0.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
+  integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
+
+acorn@^7.1.0, acorn@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
   integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
@@ -438,6 +853,22 @@ ansistyles@~0.1.3:
   resolved "https://registry.yarnpkg.com/ansistyles/-/ansistyles-0.1.3.tgz#5de60415bda071bb37127854c864f41b23254539"
   integrity sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=
 
+anymatch@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
+  integrity sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==
+  dependencies:
+    micromatch "^3.1.4"
+    normalize-path "^2.1.1"
+
+anymatch@^3.0.3:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142"
+  integrity sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
+
 aproba@^1.0.3, aproba@^1.1.1, aproba@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -473,6 +904,26 @@ argv-formatter@~1.0.0:
   resolved "https://registry.yarnpkg.com/argv-formatter/-/argv-formatter-1.0.0.tgz#a0ca0cbc29a5b73e836eebe1cbf6c5e0e4eb82f9"
   integrity sha1-oMoMvCmltz6Dbuvhy/bF4OTrgvk=
 
+arr-diff@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
+  integrity sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=
+
+arr-flatten@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
+  integrity sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==
+
+arr-union@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
+  integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
+
+array-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
+  integrity sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=
+
 array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
@@ -487,6 +938,11 @@ array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
+array-unique@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
+  integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
 arrify@^1.0.1:
   version "1.0.1"
@@ -510,6 +966,11 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
+assign-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
+  integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
@@ -519,6 +980,11 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+
+atob@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
+  integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -530,10 +996,63 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
 
+babel-jest@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-25.1.0.tgz#206093ac380a4b78c4404a05b3277391278f80fb"
+  integrity sha512-tz0VxUhhOE2y+g8R2oFrO/2VtVjA1lkJeavlhExuRBg3LdNJY9gwQ+Vcvqt9+cqy71MCTJhewvTB7Qtnnr9SWg==
+  dependencies:
+    "@jest/transform" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    "@types/babel__core" "^7.1.0"
+    babel-plugin-istanbul "^6.0.0"
+    babel-preset-jest "^25.1.0"
+    chalk "^3.0.0"
+    slash "^3.0.0"
+
+babel-plugin-istanbul@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz#e159ccdc9af95e0b570c75b4573b7c34d671d765"
+  integrity sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@istanbuljs/load-nyc-config" "^1.0.0"
+    "@istanbuljs/schema" "^0.1.2"
+    istanbul-lib-instrument "^4.0.0"
+    test-exclude "^6.0.0"
+
+babel-plugin-jest-hoist@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.1.0.tgz#fb62d7b3b53eb36c97d1bc7fec2072f9bd115981"
+  integrity sha512-oIsopO41vW4YFZ9yNYoLQATnnN46lp+MZ6H4VvPKFkcc2/fkl3CfE/NZZSmnEIEsJRmJAgkVEK0R7Zbl50CpTw==
+  dependencies:
+    "@types/babel__traverse" "^7.0.6"
+
+babel-preset-jest@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-25.1.0.tgz#d0aebfebb2177a21cde710996fce8486d34f1d33"
+  integrity sha512-eCGn64olaqwUMaugXsTtGAM2I0QTahjEtnRu0ql8Ie+gDWAc1N6wqN0k2NilnyTunM69Pad7gJY7LOtwLimoFQ==
+  dependencies:
+    "@babel/plugin-syntax-bigint" "^7.0.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
+    babel-plugin-jest-hoist "^25.1.0"
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+
+base@^0.11.1:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
+  integrity sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==
+  dependencies:
+    cache-base "^1.0.1"
+    class-utils "^0.3.5"
+    component-emitter "^1.2.1"
+    define-property "^1.0.0"
+    isobject "^3.0.1"
+    mixin-deep "^1.2.0"
+    pascalcase "^0.1.1"
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
@@ -590,6 +1109,22 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+braces@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
+  integrity sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==
+  dependencies:
+    arr-flatten "^1.1.0"
+    array-unique "^0.3.2"
+    extend-shallow "^2.0.1"
+    fill-range "^4.0.0"
+    isobject "^3.0.1"
+    repeat-element "^1.1.2"
+    snapdragon "^0.8.1"
+    snapdragon-node "^2.0.1"
+    split-string "^3.0.2"
+    to-regex "^3.0.1"
+
 braces@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
@@ -597,7 +1132,33 @@ braces@^3.0.1:
   dependencies:
     fill-range "^7.0.1"
 
-buffer-from@^1.0.0:
+browser-process-hrtime@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
+  integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
+
+browser-resolve@^1.11.3:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.3.tgz#9b7cbb3d0f510e4cb86bdbd796124d28b5890af6"
+  integrity sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==
+  dependencies:
+    resolve "1.1.7"
+
+bs-logger@0.x:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
+  integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
+  dependencies:
+    fast-json-stable-stringify "2.x"
+
+bser@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
+  integrity sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
+  dependencies:
+    node-int64 "^0.4.0"
+
+buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
@@ -638,6 +1199,21 @@ cacache@^12.0.0, cacache@^12.0.2, cacache@^12.0.3:
     unique-filename "^1.1.1"
     y18n "^4.0.0"
 
+cache-base@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
+  integrity sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==
+  dependencies:
+    collection-visit "^1.0.0"
+    component-emitter "^1.2.1"
+    get-value "^2.0.6"
+    has-value "^1.0.0"
+    isobject "^3.0.1"
+    set-value "^2.0.0"
+    to-object-path "^0.3.0"
+    union-value "^1.0.0"
+    unset-value "^1.0.0"
+
 call-limit@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/call-limit/-/call-limit-1.1.1.tgz#ef15f2670db3f1992557e2d965abc459e6e358d4"
@@ -662,10 +1238,17 @@ camelcase@^4.0.0, camelcase@^4.1.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
 
-camelcase@^5.0.0:
+camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
+capture-exit@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-2.0.0.tgz#fb953bfaebeb781f62898239dabb426d08a509a4"
+  integrity sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==
+  dependencies:
+    rsvp "^4.8.4"
 
 capture-stack-trace@^1.0.0:
   version "1.0.1"
@@ -728,6 +1311,16 @@ cidr-regex@^2.0.10:
   integrity sha512-sB3ogMQXWvreNPbJUZMRApxuRYd+KoIo4RGQ81VatjmMW6WJPo+IJZ2846FGItr9VzKo5w7DXzijPLGtSd0N3Q==
   dependencies:
     ip-regex "^2.1.0"
+
+class-utils@^0.3.5:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
+  integrity sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==
+  dependencies:
+    arr-union "^3.1.0"
+    define-property "^0.2.5"
+    isobject "^3.0.0"
+    static-extend "^0.1.1"
 
 clean-stack@^2.0.0:
   version "2.2.0"
@@ -816,10 +1409,28 @@ cmd-shim@^3.0.0, cmd-shim@^3.0.3:
     graceful-fs "^4.1.2"
     mkdirp "~0.5.0"
 
+co@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+  integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
+
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
+
+collect-v8-coverage@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.0.tgz#150ee634ac3650b71d9c985eb7f608942334feb1"
+  integrity sha512-VKIhJgvk8E1W28m5avZ2Gv2Ruv5YiF56ug2oclvaG9md69BuZImMG2sk9g7QNKLUbtYAKQjXjYxbYZVUlMMKmQ==
+
+collection-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
+  integrity sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=
+  dependencies:
+    map-visit "^1.0.0"
+    object-visit "^1.0.0"
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -882,6 +1493,11 @@ compare-func@^1.3.1:
   dependencies:
     array-ify "^1.0.0"
     dot-prop "^3.0.0"
+
+component-emitter@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
+  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -968,6 +1584,13 @@ conventional-commits-parser@^3.0.0, conventional-commits-parser@^3.0.7:
     through2 "^3.0.0"
     trim-off-newlines "^1.0.0"
 
+convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
+  integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
+  dependencies:
+    safe-buffer "~5.1.1"
+
 copy-concurrently@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/copy-concurrently/-/copy-concurrently-1.0.5.tgz#92297398cae34937fcafd6ec8139c18051f0b5e0"
@@ -979,6 +1602,11 @@ copy-concurrently@^1.0.0:
     mkdirp "^0.5.1"
     rimraf "^2.5.4"
     run-queue "^1.0.0"
+
+copy-descriptor@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
+  integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -1042,6 +1670,23 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
+cssom@^0.4.1:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.4.4.tgz#5a66cf93d2d0b661d80bf6a44fb65f5c2e4e0a10"
+  integrity sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==
+
+cssom@~0.3.6:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
+  integrity sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==
+
+cssstyle@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-2.2.0.tgz#e4c44debccd6b7911ed617a4395e5754bba59992"
+  integrity sha512-sEb3XFPx3jNnCAMtqrXPDeSgQr+jojtCeNf8cvMNMh1cG970+lljssvQDzPq6lmmJu2Vhqood/gtEomBiHOGnA==
+  dependencies:
+    cssom "~0.3.6"
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -1061,6 +1706,15 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-urls@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.1.0.tgz#15ee0582baa5e22bb59c77140da8f9c76963bbfe"
+  integrity sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==
+  dependencies:
+    abab "^2.0.0"
+    whatwg-mimetype "^2.2.0"
+    whatwg-url "^7.0.0"
+
 dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
@@ -1073,12 +1727,19 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.1:
+debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
+
+debug@^2.2.0, debug@^2.3.3:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
 
 debug@^3.1.0:
   version "3.2.6"
@@ -1134,6 +1795,28 @@ define-properties@^1.1.2, define-properties@^1.1.3:
   dependencies:
     object-keys "^1.0.12"
 
+define-property@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
+  integrity sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=
+  dependencies:
+    is-descriptor "^0.1.0"
+
+define-property@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-1.0.0.tgz#769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6"
+  integrity sha1-dp66rz9KY6rTr56NMEybvnm/sOY=
+  dependencies:
+    is-descriptor "^1.0.0"
+
+define-property@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-2.0.2.tgz#d459689e8d654ba77e02a817f8710d702cb16e9d"
+  integrity sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==
+  dependencies:
+    is-descriptor "^1.0.2"
+    isobject "^3.0.1"
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -1159,6 +1842,11 @@ detect-newline@^2.1.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
   integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
 
+detect-newline@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
+  integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
 dezalgo@^1.0.0, dezalgo@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"
@@ -1166,6 +1854,11 @@ dezalgo@^1.0.0, dezalgo@~1.0.3:
   dependencies:
     asap "^2.0.0"
     wrappy "1"
+
+diff-sequences@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.1.0.tgz#fd29a46f1c913fd66c22645dc75bffbe43051f32"
+  integrity sha512-nFIfVk5B/NStCsJ+zaPO4vYuLjlzQ6uFvPxzYyHlejNZ/UGa7G/n7peOXVrVNvRuyfstt+mZQYGpjxg9Z6N8Kw==
 
 dir-glob@^3.0.0, dir-glob@^3.0.1:
   version "3.0.1"
@@ -1180,6 +1873,13 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+domexception@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
+  integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
+  dependencies:
+    webidl-conversions "^4.0.2"
 
 dot-prop@^3.0.0:
   version "3.0.0"
@@ -1291,7 +1991,7 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.17.0-next.1:
+es-abstract@^1.17.0-next.1, es-abstract@^1.17.2:
   version "1.17.4"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.4.tgz#e3aedf19706b20e7c2594c35fc0d57605a79e184"
   integrity sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==
@@ -1333,6 +2033,18 @@ escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+
+escodegen@^1.11.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.1.tgz#ba01d0c8278b5e95a9a45350142026659027a457"
+  integrity sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==
+  dependencies:
+    esprima "^4.0.1"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.6.1"
 
 eslint-config-prettier@^6.10.0:
   version "6.10.0"
@@ -1420,7 +2132,7 @@ espree@^6.1.2:
     acorn-jsx "^5.2.0"
     eslint-visitor-keys "^1.1.0"
 
-esprima@^4.0.0, esprima@~4.0.0:
+esprima@^4.0.0, esprima@^4.0.1, esprima@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -1439,7 +2151,7 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
 
-estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
@@ -1448,6 +2160,11 @@ esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+exec-sh@^0.3.2:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.4.tgz#3a018ceb526cc6f6df2bb504b2bfe8e3a4934ec5"
+  integrity sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==
 
 execa@^0.7.0:
   version "0.7.0"
@@ -1475,6 +2192,22 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^3.2.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-3.4.0.tgz#c08ed4550ef65d858fac269ffc8572446f37eb89"
+  integrity sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==
+  dependencies:
+    cross-spawn "^7.0.0"
+    get-stream "^5.0.0"
+    human-signals "^1.1.1"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.0"
+    onetime "^5.1.0"
+    p-finally "^2.0.0"
+    signal-exit "^3.0.2"
+    strip-final-newline "^2.0.0"
+
 execa@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-4.0.0.tgz#7f37d6ec17f09e6b8fc53288611695b6d12b9daf"
@@ -1490,6 +2223,51 @@ execa@^4.0.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
+exit@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
+  integrity sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
+
+expand-brackets@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
+  integrity sha1-t3c14xXOMPa27/D4OwQVGiJEliI=
+  dependencies:
+    debug "^2.3.3"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    posix-character-classes "^0.1.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
+expect@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-25.1.0.tgz#7e8d7b06a53f7d66ec927278db3304254ee683ee"
+  integrity sha512-wqHzuoapQkhc3OKPlrpetsfueuEiMf3iWh0R8+duCu9PIjXoP7HgD5aeypwTnXUAjC8aMsiVDaWwlbJ1RlQ38g==
+  dependencies:
+    "@jest/types" "^25.1.0"
+    ansi-styles "^4.0.0"
+    jest-get-type "^25.1.0"
+    jest-matcher-utils "^25.1.0"
+    jest-message-util "^25.1.0"
+    jest-regex-util "^25.1.0"
+
+extend-shallow@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  integrity sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=
+  dependencies:
+    is-extendable "^0.1.0"
+
+extend-shallow@^3.0.0, extend-shallow@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
+  integrity sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=
+  dependencies:
+    assign-symbols "^1.0.0"
+    is-extendable "^1.0.1"
+
 extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
@@ -1503,6 +2281,20 @@ external-editor@^3.0.3:
     chardet "^0.7.0"
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
+
+extglob@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
+  integrity sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==
+  dependencies:
+    array-unique "^0.3.2"
+    define-property "^1.0.0"
+    expand-brackets "^2.1.4"
+    extend-shallow "^2.0.1"
+    fragment-cache "^0.2.1"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
 
 extsprintf@1.3.0:
   version "1.3.0"
@@ -1536,7 +2328,7 @@ fast-glob@^3.1.1:
     micromatch "^4.0.2"
     picomatch "^2.2.1"
 
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -1552,6 +2344,13 @@ fastq@^1.6.0:
   integrity sha512-mpIH5sKYueh3YyeJwqtVo8sORi0CgtmkVbK6kZStpQlZBYQuTzG2CZ7idSiJuA7bY0SFCWUc5WIs+oYumGCQNw==
   dependencies:
     reusify "^1.0.4"
+
+fb-watchman@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.1.tgz#fc84fb39d2709cf3ff6d743706157bb5708a8a85"
+  integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
+  dependencies:
+    bser "2.1.1"
 
 figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
   version "3.5.1"
@@ -1579,6 +2378,16 @@ file-entry-cache@^5.0.1:
   dependencies:
     flat-cache "^2.0.1"
 
+fill-range@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
+  integrity sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+    to-regex-range "^2.1.0"
+
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
@@ -1605,7 +2414,7 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
-find-up@^4.1.0:
+find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
@@ -1642,6 +2451,11 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+for-in@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
+  integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -1655,6 +2469,13 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+fragment-cache@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
+  integrity sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=
+  dependencies:
+    map-cache "^0.2.2"
 
 from2@^1.3.0:
   version "1.3.0"
@@ -1712,6 +2533,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
+fsevents@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.2.tgz#4c0a1fb34bc68e543b4b82a9ec392bfbda840805"
+  integrity sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -1740,6 +2566,11 @@ genfun@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/genfun/-/genfun-5.0.0.tgz#9dd9710a06900a5c4a5bf57aca5da4e52fe76537"
   integrity sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==
+
+gensync@^1.0.0-beta.1:
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"
+  integrity sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==
 
 gentle-fs@^2.3.0:
   version "2.3.0"
@@ -1792,6 +2623,11 @@ get-stream@^5.0.0:
   dependencies:
     pump "^3.0.0"
 
+get-value@^2.0.3, get-value@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
+  integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
+
 getpass@^0.1.1:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
@@ -1818,7 +2654,7 @@ glob-parent@^5.0.0, glob-parent@^5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -1836,6 +2672,11 @@ global-dirs@^0.1.0:
   integrity sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=
   dependencies:
     ini "^1.3.4"
+
+globals@^11.1.0:
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
+  integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globals@^12.1.0:
   version "12.4.0"
@@ -1877,6 +2718,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
+
+growly@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
+  integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
 handlebars@^4.4.0:
   version "4.7.3"
@@ -1922,6 +2768,37 @@ has-unicode@^2.0.0, has-unicode@~2.0.1:
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
   integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
 
+has-value@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
+  integrity sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=
+  dependencies:
+    get-value "^2.0.3"
+    has-values "^0.1.4"
+    isobject "^2.0.0"
+
+has-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-1.0.0.tgz#18b281da585b1c5c51def24c930ed29a0be6b177"
+  integrity sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=
+  dependencies:
+    get-value "^2.0.6"
+    has-values "^1.0.0"
+    isobject "^3.0.0"
+
+has-values@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-0.1.4.tgz#6d61de95d91dfca9b9a02089ad384bff8f62b771"
+  integrity sha1-bWHeldkd/Km5oCCJrThL/49it3E=
+
+has-values@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-1.0.0.tgz#95b0b63fec2146619a6fe57fe75628d5a39efe4f"
+  integrity sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=
+  dependencies:
+    is-number "^3.0.0"
+    kind-of "^4.0.0"
+
 has@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
@@ -1945,6 +2822,18 @@ hosted-git-info@^3.0.0:
   integrity sha512-4oT62d2jwSDBbLLFLZE+1vPuQ1h8p9wjrJ8Mqx5TjsyWmBMV5B13eJqn8pvluqubLf3cJPTfiYCIwNwDNmzScQ==
   dependencies:
     lru-cache "^5.1.1"
+
+html-encoding-sniffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
+  integrity sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==
+  dependencies:
+    whatwg-encoding "^1.0.1"
+
+html-escaper@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.0.tgz#71e87f931de3fe09e56661ab9a29aadec707b491"
+  integrity sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==
 
 http-cache-semantics@^3.8.1:
   version "3.8.1"
@@ -2005,7 +2894,7 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-iconv-lite@^0.4.24, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -2058,6 +2947,14 @@ import-lazy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
   integrity sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=
+
+import-local@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/import-local/-/import-local-3.0.2.tgz#a8cfd0431d1de4a2199703d003e3e62364fa6db6"
+  integrity sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==
+  dependencies:
+    pkg-dir "^4.2.0"
+    resolve-cwd "^3.0.0"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -2158,10 +3055,29 @@ ip@1.1.5:
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
   integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
 
+is-accessor-descriptor@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
+  integrity sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=
+  dependencies:
+    kind-of "^3.0.2"
+
+is-accessor-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz#169c2f6d3df1f992618072365c9b0ea1f6878656"
+  integrity sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==
+  dependencies:
+    kind-of "^6.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+
+is-buffer@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
 is-callable@^1.1.4, is-callable@^1.1.5:
   version "1.1.5"
@@ -2175,6 +3091,13 @@ is-ci@^1.0.10:
   dependencies:
     ci-info "^1.5.0"
 
+is-ci@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
+  integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
+  dependencies:
+    ci-info "^2.0.0"
+
 is-cidr@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/is-cidr/-/is-cidr-3.1.0.tgz#72e233d8e1c4cd1d3f11713fcce3eba7b0e3476f"
@@ -2182,10 +3105,54 @@ is-cidr@^3.0.0:
   dependencies:
     cidr-regex "^2.0.10"
 
+is-data-descriptor@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
+  integrity sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=
+  dependencies:
+    kind-of "^3.0.2"
+
+is-data-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
+  integrity sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==
+  dependencies:
+    kind-of "^6.0.0"
+
 is-date-object@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.2.tgz#bda736f2cd8fd06d32844e7743bfa7494c3bfd7e"
   integrity sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
+
+is-descriptor@^0.1.0:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
+  integrity sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==
+  dependencies:
+    is-accessor-descriptor "^0.1.6"
+    is-data-descriptor "^0.1.4"
+    kind-of "^5.0.0"
+
+is-descriptor@^1.0.0, is-descriptor@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec"
+  integrity sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==
+  dependencies:
+    is-accessor-descriptor "^1.0.0"
+    is-data-descriptor "^1.0.0"
+    kind-of "^6.0.2"
+
+is-extendable@^0.1.0, is-extendable@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+  integrity sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=
+
+is-extendable@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
+  integrity sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==
+  dependencies:
+    is-plain-object "^2.0.4"
 
 is-extglob@^2.1.1:
   version "2.1.1"
@@ -2209,6 +3176,11 @@ is-fullwidth-code-point@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
+is-generator-fn@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
+  integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
+
 is-glob@^4.0.0, is-glob@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
@@ -2228,6 +3200,13 @@ is-npm@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
   integrity sha1-8vtjpl5JBbQGyGBydloaTceTufQ=
+
+is-number@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
+  integrity sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=
+  dependencies:
+    kind-of "^3.0.2"
 
 is-number@^7.0.0:
   version "7.0.0"
@@ -2250,6 +3229,13 @@ is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
+
+is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+  integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
+  dependencies:
+    isobject "^3.0.1"
 
 is-plain-object@^3.0.0:
   version "3.0.0"
@@ -2304,17 +3290,27 @@ is-text-path@^1.0.1:
   dependencies:
     text-extensions "^1.0.0"
 
-is-typedarray@~1.0.0:
+is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+is-windows@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+  integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+
+is-wsl@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.1.1.tgz#4a1c152d429df3d441669498e2486d3596ebaf1d"
+  integrity sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==
 
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
   integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
-isarray@~1.0.0:
+isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
@@ -2323,6 +3319,18 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
+
+isobject@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
+  integrity sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=
+  dependencies:
+    isarray "1.0.0"
+
+isobject@^3.0.0, isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+  integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
 isobject@^4.0.0:
   version "4.0.0"
@@ -2345,10 +3353,402 @@ issue-parser@^6.0.0:
     lodash.isstring "^4.0.1"
     lodash.uniqby "^4.7.0"
 
+istanbul-lib-coverage@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz#f5944a37c70b550b02a78a5c3b2055b280cec8ec"
+  integrity sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==
+
+istanbul-lib-instrument@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.1.tgz#61f13ac2c96cfefb076fe7131156cc05907874e6"
+  integrity sha512-imIchxnodll7pvQBYOqUu88EufLCU56LMeFPZZM/fJZ1irYcYdqroaV+ACK1Ila8ls09iEYArp+nqyC6lW1Vfg==
+  dependencies:
+    "@babel/core" "^7.7.5"
+    "@babel/parser" "^7.7.5"
+    "@babel/template" "^7.7.4"
+    "@babel/traverse" "^7.7.4"
+    "@istanbuljs/schema" "^0.1.2"
+    istanbul-lib-coverage "^3.0.0"
+    semver "^6.3.0"
+
+istanbul-lib-report@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz#7518fe52ea44de372f460a76b5ecda9ffb73d8a6"
+  integrity sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==
+  dependencies:
+    istanbul-lib-coverage "^3.0.0"
+    make-dir "^3.0.0"
+    supports-color "^7.1.0"
+
+istanbul-lib-source-maps@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz#75743ce6d96bb86dc7ee4352cf6366a23f0b1ad9"
+  integrity sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==
+  dependencies:
+    debug "^4.1.1"
+    istanbul-lib-coverage "^3.0.0"
+    source-map "^0.6.1"
+
+istanbul-reports@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.0.0.tgz#d4d16d035db99581b6194e119bbf36c963c5eb70"
+  integrity sha512-2osTcC8zcOSUkImzN2EWQta3Vdi4WjjKw99P2yWx5mLnigAM0Rd5uYFn1cf2i/Ois45GkNjaoTqc5CxgMSX80A==
+  dependencies:
+    html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
+
 java-properties@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/java-properties/-/java-properties-1.0.2.tgz#ccd1fa73907438a5b5c38982269d0e771fe78211"
   integrity sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==
+
+jest-changed-files@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-25.1.0.tgz#73dae9a7d9949fdfa5c278438ce8f2ff3ec78131"
+  integrity sha512-bdL1aHjIVy3HaBO3eEQeemGttsq1BDlHgWcOjEOIAcga7OOEGWHD2WSu8HhL7I1F0mFFyci8VKU4tRNk+qtwDA==
+  dependencies:
+    "@jest/types" "^25.1.0"
+    execa "^3.2.0"
+    throat "^5.0.0"
+
+jest-cli@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-25.1.0.tgz#75f0b09cf6c4f39360906bf78d580be1048e4372"
+  integrity sha512-p+aOfczzzKdo3AsLJlhs8J5EW6ffVidfSZZxXedJ0mHPBOln1DccqFmGCoO8JWd4xRycfmwy1eoQkMsF8oekPg==
+  dependencies:
+    "@jest/core" "^25.1.0"
+    "@jest/test-result" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    chalk "^3.0.0"
+    exit "^0.1.2"
+    import-local "^3.0.2"
+    is-ci "^2.0.0"
+    jest-config "^25.1.0"
+    jest-util "^25.1.0"
+    jest-validate "^25.1.0"
+    prompts "^2.0.1"
+    realpath-native "^1.1.0"
+    yargs "^15.0.0"
+
+jest-config@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-25.1.0.tgz#d114e4778c045d3ef239452213b7ad3ec1cbea90"
+  integrity sha512-tLmsg4SZ5H7tuhBC5bOja0HEblM0coS3Wy5LTCb2C8ZV6eWLewHyK+3qSq9Bi29zmWQ7ojdCd3pxpx4l4d2uGw==
+  dependencies:
+    "@babel/core" "^7.1.0"
+    "@jest/test-sequencer" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    babel-jest "^25.1.0"
+    chalk "^3.0.0"
+    glob "^7.1.1"
+    jest-environment-jsdom "^25.1.0"
+    jest-environment-node "^25.1.0"
+    jest-get-type "^25.1.0"
+    jest-jasmine2 "^25.1.0"
+    jest-regex-util "^25.1.0"
+    jest-resolve "^25.1.0"
+    jest-util "^25.1.0"
+    jest-validate "^25.1.0"
+    micromatch "^4.0.2"
+    pretty-format "^25.1.0"
+    realpath-native "^1.1.0"
+
+jest-diff@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.1.0.tgz#58b827e63edea1bc80c1de952b80cec9ac50e1ad"
+  integrity sha512-nepXgajT+h017APJTreSieh4zCqnSHEJ1iT8HDlewu630lSJ4Kjjr9KNzm+kzGwwcpsDE6Snx1GJGzzsefaEHw==
+  dependencies:
+    chalk "^3.0.0"
+    diff-sequences "^25.1.0"
+    jest-get-type "^25.1.0"
+    pretty-format "^25.1.0"
+
+jest-docblock@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-25.1.0.tgz#0f44bea3d6ca6dfc38373d465b347c8818eccb64"
+  integrity sha512-370P/mh1wzoef6hUKiaMcsPtIapY25suP6JqM70V9RJvdKLrV4GaGbfUseUVk4FZJw4oTZ1qSCJNdrClKt5JQA==
+  dependencies:
+    detect-newline "^3.0.0"
+
+jest-each@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-25.1.0.tgz#a6b260992bdf451c2d64a0ccbb3ac25e9b44c26a"
+  integrity sha512-R9EL8xWzoPySJ5wa0DXFTj7NrzKpRD40Jy+zQDp3Qr/2QmevJgkN9GqioCGtAJ2bW9P/MQRznQHQQhoeAyra7A==
+  dependencies:
+    "@jest/types" "^25.1.0"
+    chalk "^3.0.0"
+    jest-get-type "^25.1.0"
+    jest-util "^25.1.0"
+    pretty-format "^25.1.0"
+
+jest-environment-jsdom@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-25.1.0.tgz#6777ab8b3e90fd076801efd3bff8e98694ab43c3"
+  integrity sha512-ILb4wdrwPAOHX6W82GGDUiaXSSOE274ciuov0lztOIymTChKFtC02ddyicRRCdZlB5YSrv3vzr1Z5xjpEe1OHQ==
+  dependencies:
+    "@jest/environment" "^25.1.0"
+    "@jest/fake-timers" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    jest-mock "^25.1.0"
+    jest-util "^25.1.0"
+    jsdom "^15.1.1"
+
+jest-environment-node@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-25.1.0.tgz#797bd89b378cf0bd794dc8e3dca6ef21126776db"
+  integrity sha512-U9kFWTtAPvhgYY5upnH9rq8qZkj6mYLup5l1caAjjx9uNnkLHN2xgZy5mo4SyLdmrh/EtB9UPpKFShvfQHD0Iw==
+  dependencies:
+    "@jest/environment" "^25.1.0"
+    "@jest/fake-timers" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    jest-mock "^25.1.0"
+    jest-util "^25.1.0"
+
+jest-get-type@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.1.0.tgz#1cfe5fc34f148dc3a8a3b7275f6b9ce9e2e8a876"
+  integrity sha512-yWkBnT+5tMr8ANB6V+OjmrIJufHtCAqI5ic2H40v+tRqxDmE0PGnIiTyvRWFOMtmVHYpwRqyazDbTnhpjsGvLw==
+
+jest-haste-map@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-25.1.0.tgz#ae12163d284f19906260aa51fd405b5b2e5a4ad3"
+  integrity sha512-/2oYINIdnQZAqyWSn1GTku571aAfs8NxzSErGek65Iu5o8JYb+113bZysRMcC/pjE5v9w0Yz+ldbj9NxrFyPyw==
+  dependencies:
+    "@jest/types" "^25.1.0"
+    anymatch "^3.0.3"
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.2.3"
+    jest-serializer "^25.1.0"
+    jest-util "^25.1.0"
+    jest-worker "^25.1.0"
+    micromatch "^4.0.2"
+    sane "^4.0.3"
+    walker "^1.0.7"
+  optionalDependencies:
+    fsevents "^2.1.2"
+
+jest-jasmine2@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-25.1.0.tgz#681b59158a430f08d5d0c1cce4f01353e4b48137"
+  integrity sha512-GdncRq7jJ7sNIQ+dnXvpKO2MyP6j3naNK41DTTjEAhLEdpImaDA9zSAZwDhijjSF/D7cf4O5fdyUApGBZleaEg==
+  dependencies:
+    "@babel/traverse" "^7.1.0"
+    "@jest/environment" "^25.1.0"
+    "@jest/source-map" "^25.1.0"
+    "@jest/test-result" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    chalk "^3.0.0"
+    co "^4.6.0"
+    expect "^25.1.0"
+    is-generator-fn "^2.0.0"
+    jest-each "^25.1.0"
+    jest-matcher-utils "^25.1.0"
+    jest-message-util "^25.1.0"
+    jest-runtime "^25.1.0"
+    jest-snapshot "^25.1.0"
+    jest-util "^25.1.0"
+    pretty-format "^25.1.0"
+    throat "^5.0.0"
+
+jest-leak-detector@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-25.1.0.tgz#ed6872d15aa1c72c0732d01bd073dacc7c38b5c6"
+  integrity sha512-3xRI264dnhGaMHRvkFyEKpDeaRzcEBhyNrOG5oT8xPxOyUAblIAQnpiR3QXu4wDor47MDTiHbiFcbypdLcLW5w==
+  dependencies:
+    jest-get-type "^25.1.0"
+    pretty-format "^25.1.0"
+
+jest-matcher-utils@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-25.1.0.tgz#fa5996c45c7193a3c24e73066fc14acdee020220"
+  integrity sha512-KGOAFcSFbclXIFE7bS4C53iYobKI20ZWleAdAFun4W1Wz1Kkej8Ng6RRbhL8leaEvIOjGXhGf/a1JjO8bkxIWQ==
+  dependencies:
+    chalk "^3.0.0"
+    jest-diff "^25.1.0"
+    jest-get-type "^25.1.0"
+    pretty-format "^25.1.0"
+
+jest-message-util@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-25.1.0.tgz#702a9a5cb05c144b9aa73f06e17faa219389845e"
+  integrity sha512-Nr/Iwar2COfN22aCqX0kCVbXgn8IBm9nWf4xwGr5Olv/KZh0CZ32RKgZWMVDXGdOahicM10/fgjdimGNX/ttCQ==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@jest/test-result" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    "@types/stack-utils" "^1.0.1"
+    chalk "^3.0.0"
+    micromatch "^4.0.2"
+    slash "^3.0.0"
+    stack-utils "^1.0.1"
+
+jest-mock@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-25.1.0.tgz#411d549e1b326b7350b2e97303a64715c28615fd"
+  integrity sha512-28/u0sqS+42vIfcd1mlcg4ZVDmSUYuNvImP4X2lX5hRMLW+CN0BeiKVD4p+ujKKbSPKd3rg/zuhCF+QBLJ4vag==
+  dependencies:
+    "@jest/types" "^25.1.0"
+
+jest-pnp-resolver@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz#ecdae604c077a7fbc70defb6d517c3c1c898923a"
+  integrity sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==
+
+jest-regex-util@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-25.1.0.tgz#efaf75914267741838e01de24da07b2192d16d87"
+  integrity sha512-9lShaDmDpqwg+xAd73zHydKrBbbrIi08Kk9YryBEBybQFg/lBWR/2BDjjiSE7KIppM9C5+c03XiDaZ+m4Pgs1w==
+
+jest-resolve-dependencies@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-25.1.0.tgz#8a1789ec64eb6aaa77fd579a1066a783437e70d2"
+  integrity sha512-Cu/Je38GSsccNy4I2vL12ZnBlD170x2Oh1devzuM9TLH5rrnLW1x51lN8kpZLYTvzx9j+77Y5pqBaTqfdzVzrw==
+  dependencies:
+    "@jest/types" "^25.1.0"
+    jest-regex-util "^25.1.0"
+    jest-snapshot "^25.1.0"
+
+jest-resolve@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-25.1.0.tgz#23d8b6a4892362baf2662877c66aa241fa2eaea3"
+  integrity sha512-XkBQaU1SRCHj2Evz2Lu4Czs+uIgJXWypfO57L7JYccmAXv4slXA6hzNblmcRmf7P3cQ1mE7fL3ABV6jAwk4foQ==
+  dependencies:
+    "@jest/types" "^25.1.0"
+    browser-resolve "^1.11.3"
+    chalk "^3.0.0"
+    jest-pnp-resolver "^1.2.1"
+    realpath-native "^1.1.0"
+
+jest-runner@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-25.1.0.tgz#fef433a4d42c89ab0a6b6b268e4a4fbe6b26e812"
+  integrity sha512-su3O5fy0ehwgt+e8Wy7A8CaxxAOCMzL4gUBftSs0Ip32S0epxyZPDov9Znvkl1nhVOJNf4UwAsnqfc3plfQH9w==
+  dependencies:
+    "@jest/console" "^25.1.0"
+    "@jest/environment" "^25.1.0"
+    "@jest/test-result" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    chalk "^3.0.0"
+    exit "^0.1.2"
+    graceful-fs "^4.2.3"
+    jest-config "^25.1.0"
+    jest-docblock "^25.1.0"
+    jest-haste-map "^25.1.0"
+    jest-jasmine2 "^25.1.0"
+    jest-leak-detector "^25.1.0"
+    jest-message-util "^25.1.0"
+    jest-resolve "^25.1.0"
+    jest-runtime "^25.1.0"
+    jest-util "^25.1.0"
+    jest-worker "^25.1.0"
+    source-map-support "^0.5.6"
+    throat "^5.0.0"
+
+jest-runtime@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-25.1.0.tgz#02683218f2f95aad0f2ec1c9cdb28c1dc0ec0314"
+  integrity sha512-mpPYYEdbExKBIBB16ryF6FLZTc1Rbk9Nx0ryIpIMiDDkOeGa0jQOKVI/QeGvVGlunKKm62ywcioeFVzIbK03bA==
+  dependencies:
+    "@jest/console" "^25.1.0"
+    "@jest/environment" "^25.1.0"
+    "@jest/source-map" "^25.1.0"
+    "@jest/test-result" "^25.1.0"
+    "@jest/transform" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    "@types/yargs" "^15.0.0"
+    chalk "^3.0.0"
+    collect-v8-coverage "^1.0.0"
+    exit "^0.1.2"
+    glob "^7.1.3"
+    graceful-fs "^4.2.3"
+    jest-config "^25.1.0"
+    jest-haste-map "^25.1.0"
+    jest-message-util "^25.1.0"
+    jest-mock "^25.1.0"
+    jest-regex-util "^25.1.0"
+    jest-resolve "^25.1.0"
+    jest-snapshot "^25.1.0"
+    jest-util "^25.1.0"
+    jest-validate "^25.1.0"
+    realpath-native "^1.1.0"
+    slash "^3.0.0"
+    strip-bom "^4.0.0"
+    yargs "^15.0.0"
+
+jest-serializer@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-25.1.0.tgz#73096ba90e07d19dec4a0c1dd89c355e2f129e5d"
+  integrity sha512-20Wkq5j7o84kssBwvyuJ7Xhn7hdPeTXndnwIblKDR2/sy1SUm6rWWiG9kSCgJPIfkDScJCIsTtOKdlzfIHOfKA==
+
+jest-snapshot@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-25.1.0.tgz#d5880bd4b31faea100454608e15f8d77b9d221d9"
+  integrity sha512-xZ73dFYN8b/+X2hKLXz4VpBZGIAn7muD/DAg+pXtDzDGw3iIV10jM7WiHqhCcpDZfGiKEj7/2HXAEPtHTj0P2A==
+  dependencies:
+    "@babel/types" "^7.0.0"
+    "@jest/types" "^25.1.0"
+    chalk "^3.0.0"
+    expect "^25.1.0"
+    jest-diff "^25.1.0"
+    jest-get-type "^25.1.0"
+    jest-matcher-utils "^25.1.0"
+    jest-message-util "^25.1.0"
+    jest-resolve "^25.1.0"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    pretty-format "^25.1.0"
+    semver "^7.1.1"
+
+jest-util@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-25.1.0.tgz#7bc56f7b2abd534910e9fa252692f50624c897d9"
+  integrity sha512-7did6pLQ++87Qsj26Fs/TIwZMUFBXQ+4XXSodRNy3luch2DnRXsSnmpVtxxQ0Yd6WTipGpbhh2IFP1mq6/fQGw==
+  dependencies:
+    "@jest/types" "^25.1.0"
+    chalk "^3.0.0"
+    is-ci "^2.0.0"
+    mkdirp "^0.5.1"
+
+jest-validate@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-25.1.0.tgz#1469fa19f627bb0a9a98e289f3e9ab6a668c732a"
+  integrity sha512-kGbZq1f02/zVO2+t1KQGSVoCTERc5XeObLwITqC6BTRH3Adv7NZdYqCpKIZLUgpLXf2yISzQ465qOZpul8abXA==
+  dependencies:
+    "@jest/types" "^25.1.0"
+    camelcase "^5.3.1"
+    chalk "^3.0.0"
+    jest-get-type "^25.1.0"
+    leven "^3.1.0"
+    pretty-format "^25.1.0"
+
+jest-watcher@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-25.1.0.tgz#97cb4a937f676f64c9fad2d07b824c56808e9806"
+  integrity sha512-Q9eZ7pyaIr6xfU24OeTg4z1fUqBF/4MP6J801lyQfg7CsnZ/TCzAPvCfckKdL5dlBBEKBeHV0AdyjFZ5eWj4ig==
+  dependencies:
+    "@jest/test-result" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    ansi-escapes "^4.2.1"
+    chalk "^3.0.0"
+    jest-util "^25.1.0"
+    string-length "^3.1.0"
+
+jest-worker@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-25.1.0.tgz#75d038bad6fdf58eba0d2ec1835856c497e3907a"
+  integrity sha512-ZHhHtlxOWSxCoNOKHGbiLzXnl42ga9CxDr27H36Qn+15pQZd3R/F24jrmjDelw9j/iHUIWMWs08/u2QN50HHOg==
+  dependencies:
+    merge-stream "^2.0.0"
+    supports-color "^7.0.0"
+
+jest@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-25.1.0.tgz#b85ef1ddba2fdb00d295deebbd13567106d35be9"
+  integrity sha512-FV6jEruneBhokkt9MQk0WUFoNTwnF76CLXtwNMfsc0um0TlB/LG2yxUd0KqaFjEJ9laQmVWQWS0sG/t2GsuI0w==
+  dependencies:
+    "@jest/core" "^25.1.0"
+    import-local "^3.0.2"
+    jest-cli "^25.1.0"
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -2367,6 +3767,43 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
+
+jsdom@^15.1.1:
+  version "15.2.1"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-15.2.1.tgz#d2feb1aef7183f86be521b8c6833ff5296d07ec5"
+  integrity sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==
+  dependencies:
+    abab "^2.0.0"
+    acorn "^7.1.0"
+    acorn-globals "^4.3.2"
+    array-equal "^1.0.0"
+    cssom "^0.4.1"
+    cssstyle "^2.0.0"
+    data-urls "^1.1.0"
+    domexception "^1.0.1"
+    escodegen "^1.11.1"
+    html-encoding-sniffer "^1.0.2"
+    nwsapi "^2.2.0"
+    parse5 "5.1.0"
+    pn "^1.1.0"
+    request "^2.88.0"
+    request-promise-native "^1.0.7"
+    saxes "^3.1.9"
+    symbol-tree "^3.2.2"
+    tough-cookie "^3.0.1"
+    w3c-hr-time "^1.0.1"
+    w3c-xmlserializer "^1.1.2"
+    webidl-conversions "^4.0.2"
+    whatwg-encoding "^1.0.5"
+    whatwg-mimetype "^2.3.0"
+    whatwg-url "^7.0.0"
+    ws "^7.0.0"
+    xml-name-validator "^3.0.0"
+
+jsesc@^2.5.1:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
+  integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
 json-parse-better-errors@^1.0.0, json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
@@ -2393,6 +3830,13 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
+json5@2.x, json5@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.2.tgz#43ef1f0af9835dd624751a6b7fa48874fb2d608e"
+  integrity sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==
+  dependencies:
+    minimist "^1.2.5"
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -2414,6 +3858,35 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
+  integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
+  dependencies:
+    is-buffer "^1.1.5"
+
+kind-of@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
+  integrity sha1-IIE989cSkosgc3hpGkUGb65y3Vc=
+  dependencies:
+    is-buffer "^1.1.5"
+
+kind-of@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
+  integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
+
+kind-of@^6.0.0, kind-of@^6.0.2:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
+  integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+kleur@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
+  integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
 latest-version@^3.0.0:
   version "3.1.0"
@@ -2440,6 +3913,11 @@ lcid@^2.0.0:
   integrity sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==
   dependencies:
     invert-kv "^2.0.0"
+
+leven@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
+  integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
 
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
@@ -2695,6 +4173,16 @@ lodash.isstring@^4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
 
+lodash.memoize@4.x:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+  integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
+lodash.sortby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
+  integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
+
 lodash.toarray@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
@@ -2720,10 +4208,17 @@ lodash.without@~4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
   integrity sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=
 
-lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
+lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lolex@^5.0.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-5.1.2.tgz#953694d098ce7c07bc5ed6d0e42bc6c0c6d5a367"
+  integrity sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -2765,6 +4260,18 @@ make-dir@^1.0.0:
   dependencies:
     pify "^3.0.0"
 
+make-dir@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.0.2.tgz#04a1acbf22221e1d6ef43559f43e05a90dbb4392"
+  integrity sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==
+  dependencies:
+    semver "^6.0.0"
+
+make-error@1.x:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
 make-fetch-happen@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-5.0.2.tgz#aa8387104f2687edca01c8687ee45013d02d19bd"
@@ -2782,12 +4289,24 @@ make-fetch-happen@^5.0.0:
     socks-proxy-agent "^4.0.0"
     ssri "^6.0.0"
 
+makeerror@1.0.x:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
+  integrity sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=
+  dependencies:
+    tmpl "1.0.x"
+
 map-age-cleaner@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
   integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
   dependencies:
     p-defer "^1.0.0"
+
+map-cache@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
+  integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
 
 map-obj@^1.0.0:
   version "1.0.1"
@@ -2798,6 +4317,13 @@ map-obj@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9"
   integrity sha1-plzSkIepJZi4eRJXpSPgISIqwfk=
+
+map-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
+  integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
+  dependencies:
+    object-visit "^1.0.0"
 
 marked-terminal@^4.0.0:
   version "4.0.0"
@@ -2862,6 +4388,25 @@ merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
   integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
 
+micromatch@^3.1.4:
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
+  integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    braces "^2.3.1"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    extglob "^2.0.4"
+    fragment-cache "^0.2.1"
+    kind-of "^6.0.2"
+    nanomatch "^1.2.9"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.2"
+
 micromatch@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
@@ -2917,7 +4462,7 @@ minimist@0.0.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
-minimist@^1.2.0:
+minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -2958,6 +4503,21 @@ mississippi@^3.0.0:
     stream-each "^1.1.0"
     through2 "^2.0.0"
 
+mixin-deep@^1.2.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
+  integrity sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==
+  dependencies:
+    for-in "^1.0.2"
+    is-extendable "^1.0.1"
+
+mkdirp@0.x:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.3.tgz#5a514b7179259287952881e94410ec5465659f8c"
+  integrity sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==
+  dependencies:
+    minimist "^1.2.5"
+
 mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
@@ -2996,6 +4556,23 @@ mute-stream@0.0.8, mute-stream@~0.0.4:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
+nanomatch@^1.2.9:
+  version "1.2.13"
+  resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
+  integrity sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    fragment-cache "^0.2.1"
+    is-windows "^1.0.2"
+    kind-of "^6.0.2"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -3055,6 +4632,27 @@ node-gyp@^5.0.2, node-gyp@^5.1.0:
     tar "^4.4.12"
     which "^1.3.1"
 
+node-int64@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
+  integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
+
+node-modules-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
+  integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
+
+node-notifier@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-6.0.0.tgz#cea319e06baa16deec8ce5cd7f133c4a46b68e12"
+  integrity sha512-SVfQ/wMw+DesunOm5cKqr6yDcvUTDl/yc97ybGHMrteNEY6oekXpNpS3lZwgLlwz0FLgHoiW28ZpmBHUDg37cw==
+  dependencies:
+    growly "^1.3.0"
+    is-wsl "^2.1.1"
+    semver "^6.3.0"
+    shellwords "^0.1.1"
+    which "^1.3.1"
+
 nopt@^4.0.1, nopt@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.3.tgz#a375cad9d02fd921278d954c2254d5aa57e15e48"
@@ -3072,6 +4670,18 @@ normalize-package-data@^2.0.0, normalize-package-data@^2.3.2, normalize-package-
     resolve "^1.10.0"
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
+
+normalize-path@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
+  integrity sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=
+  dependencies:
+    remove-trailing-separator "^1.0.1"
+
+normalize-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
 normalize-url@^5.0.0:
   version "5.0.0"
@@ -3334,6 +4944,11 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
+nwsapi@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
+  integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
+
 oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
@@ -3343,6 +4958,15 @@ object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+
+object-copy@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
+  integrity sha1-fn2Fi3gb18mRpBupde04EnVOmYw=
+  dependencies:
+    copy-descriptor "^0.1.0"
+    define-property "^0.2.5"
+    kind-of "^3.0.3"
 
 object-inspect@^1.7.0:
   version "1.7.0"
@@ -3354,6 +4978,13 @@ object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
+object-visit@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
+  integrity sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=
+  dependencies:
+    isobject "^3.0.0"
+
 object.assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
@@ -3364,13 +4995,20 @@ object.assign@^4.1.0:
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
 
-object.getownpropertydescriptors@^2.0.3:
+object.getownpropertydescriptors@^2.0.3, object.getownpropertydescriptors@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz#369bf1f9592d8ab89d712dced5cb81c7c5352649"
   integrity sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==
   dependencies:
     define-properties "^1.1.3"
     es-abstract "^1.17.0-next.1"
+
+object.pick@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
+  integrity sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
+  dependencies:
+    isobject "^3.0.1"
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0, once@~1.4.0:
   version "1.4.0"
@@ -3399,7 +5037,7 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-optionator@^0.8.3:
+optionator@^0.8.1, optionator@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
   integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
@@ -3476,6 +5114,11 @@ p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
+
+p-finally@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-2.0.1.tgz#bd6fcaa9c559a096b680806f4d657b3f0f240561"
+  integrity sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==
 
 p-is-promise@^2.0.0:
   version "2.1.0"
@@ -3637,6 +5280,16 @@ parse-json@^5.0.0:
     json-parse-better-errors "^1.0.1"
     lines-and-columns "^1.1.6"
 
+parse5@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
+  integrity sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==
+
+pascalcase@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
+  integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
@@ -3696,7 +5349,7 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picomatch@^2.0.5, picomatch@^2.2.1:
+picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
   integrity sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==
@@ -3711,6 +5364,13 @@ pify@^3.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
+pirates@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
+  integrity sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
+  dependencies:
+    node-modules-regexp "^1.0.0"
+
 pkg-conf@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/pkg-conf/-/pkg-conf-2.1.0.tgz#2126514ca6f2abfebd168596df18ba57867f0058"
@@ -3718,6 +5378,23 @@ pkg-conf@^2.1.0:
   dependencies:
     find-up "^2.0.0"
     load-json-file "^4.0.0"
+
+pkg-dir@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
+  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
+  dependencies:
+    find-up "^4.0.0"
+
+pn@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
+  integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
+
+posix-character-classes@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
+  integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -3741,6 +5418,16 @@ prettier@^1.19.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
+pretty-format@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.1.0.tgz#ed869bdaec1356fc5ae45de045e2c8ec7b07b0c8"
+  integrity sha512-46zLRSGLd02Rp+Lhad9zzuNZ+swunitn8zIpfD2B4OPCRLXbM87RJT2aBLBWYOznNUML/2l/ReMyWNC80PJBUQ==
+  dependencies:
+    "@jest/types" "^25.1.0"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -3763,6 +5450,14 @@ promise-retry@^1.1.1:
   dependencies:
     err-code "^1.0.0"
     retry "^0.10.0"
+
+prompts@^2.0.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.3.1.tgz#b63a9ce2809f106fa9ae1277c275b167af46ea05"
+  integrity sha512-qIP2lQyCwYbdzcqHIUi2HAxiWixhoM9OdLCWf8txXsapC/X9YdsCoeyRIXE/GP+Q0J37Q7+XN/MFqbUa7IzXNA==
+  dependencies:
+    kleur "^3.0.3"
+    sisteransi "^1.0.4"
 
 promzard@^0.3.0:
   version "0.3.0"
@@ -3871,6 +5566,11 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.8:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-is@^16.12.0:
+  version "16.13.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
+  integrity sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==
 
 read-cmd-shim@^1.0.1, read-cmd-shim@^1.0.5:
   version "1.0.5"
@@ -4016,6 +5716,13 @@ readdir-scoped-modules@^1.0.0, readdir-scoped-modules@^1.1.0:
     graceful-fs "^4.1.2"
     once "^1.3.0"
 
+realpath-native@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.1.0.tgz#2003294fea23fb0672f2476ebe22fcf498a2d65c"
+  integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
+  dependencies:
+    util.promisify "^1.0.0"
+
 redent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-2.0.0.tgz#c1b2007b42d57eb1389079b3c8333639d5e1ccaa"
@@ -4035,6 +5742,14 @@ regenerator-runtime@^0.13.4:
   version "0.13.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
   integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
+
+regex-not@^1.0.0, regex-not@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
+  integrity sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==
+  dependencies:
+    extend-shallow "^3.0.2"
+    safe-regex "^1.1.0"
 
 regexpp@^2.0.1:
   version "2.0.1"
@@ -4067,6 +5782,37 @@ registry-url@^3.0.3:
   integrity sha1-PU74cPc93h138M+aOBQyRE4XSUI=
   dependencies:
     rc "^1.0.1"
+
+remove-trailing-separator@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
+  integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
+
+repeat-element@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
+  integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
+
+repeat-string@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
+  integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
+
+request-promise-core@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.3.tgz#e9a3c081b51380dfea677336061fea879a829ee9"
+  integrity sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==
+  dependencies:
+    lodash "^4.17.15"
+
+request-promise-native@^1.0.7:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.8.tgz#a455b960b826e44e2bf8999af64dff2bfe58cb36"
+  integrity sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==
+  dependencies:
+    request-promise-core "1.1.3"
+    stealthy-require "^1.1.1"
+    tough-cookie "^2.3.3"
 
 request@^2.88.0:
   version "2.88.2"
@@ -4109,6 +5855,13 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
+resolve-cwd@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
+  integrity sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==
+  dependencies:
+    resolve-from "^5.0.0"
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -4119,7 +5872,17 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-resolve@^1.10.0:
+resolve-url@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
+  integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
+
+resolve@1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+  integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
+
+resolve@1.x, resolve@^1.10.0, resolve@^1.3.2:
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
   integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
@@ -4133,6 +5896,11 @@ restore-cursor@^3.1.0:
   dependencies:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
+
+ret@~0.1.10:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
+  integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
 retry@^0.10.0:
   version "0.10.1"
@@ -4162,6 +5930,18 @@ rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
   dependencies:
     glob "^7.1.3"
+
+rimraf@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
+rsvp@^4.8.4:
+  version "4.8.5"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
+  integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
 run-async@^2.4.0:
   version "2.4.0"
@@ -4199,10 +5979,39 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
+safe-regex@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
+  integrity sha1-QKNmnzsHfR6UPURinhV91IAjvy4=
+  dependencies:
+    ret "~0.1.10"
+
 "safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+sane@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/sane/-/sane-4.1.0.tgz#ed881fd922733a6c461bc189dc2b6c006f3ffded"
+  integrity sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==
+  dependencies:
+    "@cnakazawa/watch" "^1.0.3"
+    anymatch "^2.0.0"
+    capture-exit "^2.0.0"
+    exec-sh "^0.3.2"
+    execa "^1.0.0"
+    fb-watchman "^2.0.0"
+    micromatch "^3.1.4"
+    minimist "^1.1.1"
+    walker "~1.0.5"
+
+saxes@^3.1.9:
+  version "3.1.11"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-3.1.11.tgz#d59d1fd332ec92ad98a2e0b2ee644702384b1c5b"
+  integrity sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==
+  dependencies:
+    xmlchars "^2.1.1"
 
 semantic-release@^17.0.4:
   version "17.0.4"
@@ -4257,7 +6066,7 @@ semver-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
   integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
 
-"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -4276,6 +6085,16 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+set-value@^2.0.0, set-value@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
+  integrity sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.3"
+    split-string "^3.0.1"
 
 sha@^3.0.0:
   version "3.0.0"
@@ -4308,6 +6127,11 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+shellwords@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
+  integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -4321,6 +6145,11 @@ signale@^1.2.1:
     chalk "^2.3.2"
     figures "^2.0.0"
     pkg-conf "^2.1.0"
+
+sisteransi@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.4.tgz#386713f1ef688c7c0304dc4c0632898941cad2e3"
+  integrity sha512-/ekMoM4NJ59ivGSfKapeG+FWtrmWvA1p6FBZwXrqojw90vJu8lBmrTxCMuBCydKtkaUe2zt4PlxeTKpjwMbyig==
 
 slash@^3.0.0:
   version "3.0.0"
@@ -4345,6 +6174,36 @@ smart-buffer@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.1.0.tgz#91605c25d91652f4661ea69ccf45f1b331ca21ba"
   integrity sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==
+
+snapdragon-node@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
+  integrity sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==
+  dependencies:
+    define-property "^1.0.0"
+    isobject "^3.0.0"
+    snapdragon-util "^3.0.1"
+
+snapdragon-util@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz#f956479486f2acd79700693f6f7b805e45ab56e2"
+  integrity sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==
+  dependencies:
+    kind-of "^3.2.0"
+
+snapdragon@^0.8.1:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/snapdragon/-/snapdragon-0.8.2.tgz#64922e7c565b0e14204ba1aa7d6964278d25182d"
+  integrity sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==
+  dependencies:
+    base "^0.11.1"
+    debug "^2.2.0"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    map-cache "^0.2.2"
+    source-map "^0.5.6"
+    source-map-resolve "^0.5.0"
+    use "^3.1.0"
 
 socks-proxy-agent@^4.0.0:
   version "4.0.2"
@@ -4375,10 +6234,44 @@ sorted-union-stream@~2.1.3:
     from2 "^1.3.0"
     stream-iterate "^1.1.0"
 
-source-map@^0.6.1, source-map@~0.6.1:
+source-map-resolve@^0.5.0:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
+  integrity sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==
+  dependencies:
+    atob "^2.1.2"
+    decode-uri-component "^0.2.0"
+    resolve-url "^0.2.1"
+    source-map-url "^0.4.0"
+    urix "^0.1.0"
+
+source-map-support@^0.5.6:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
+  integrity sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map-url@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
+  integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
+
+source-map@^0.5.0, source-map@^0.5.6:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+  integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
+
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+source-map@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 spawn-error-forwarder@~1.0.0:
   version "1.0.0"
@@ -4415,6 +6308,13 @@ split-on-first@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
   integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
+split-string@^3.0.1, split-string@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
+  integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
+  dependencies:
+    extend-shallow "^3.0.0"
 
 split2@^2.0.0:
   version "2.2.0"
@@ -4464,6 +6364,24 @@ ssri@^6.0.0, ssri@^6.0.1:
   dependencies:
     figgy-pudding "^3.5.1"
 
+stack-utils@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
+  integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
+
+static-extend@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
+  integrity sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=
+  dependencies:
+    define-property "^0.2.5"
+    object-copy "^0.1.0"
+
+stealthy-require@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
+  integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
+
 stream-combiner2@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stream-combiner2/-/stream-combiner2-1.1.1.tgz#fb4d8a1420ea362764e21ad4780397bebcb41cbe"
@@ -4497,6 +6415,14 @@ strict-uri-encode@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
   integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
+
+string-length@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-length/-/string-length-3.1.0.tgz#107ef8c23456e187a8abd4a61162ff4ac6e25837"
+  integrity sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==
+  dependencies:
+    astral-regex "^1.0.0"
+    strip-ansi "^5.2.0"
 
 string-width@^1.0.1:
   version "1.0.2"
@@ -4606,6 +6532,11 @@ strip-bom@^3.0.0:
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
   integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
 
+strip-bom@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
+  integrity sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==
+
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
@@ -4653,6 +6584,11 @@ supports-hyperlinks@^2.0.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
+symbol-tree@^3.2.2:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
+  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
 table@^5.2.3:
   version "5.4.6"
   resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
@@ -4698,6 +6634,23 @@ term-size@^1.2.0:
   dependencies:
     execa "^0.7.0"
 
+terminal-link@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-2.1.1.tgz#14a64a27ab3c0df933ea546fba55f2d078edc994"
+  integrity sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    supports-hyperlinks "^2.0.0"
+
+test-exclude@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-6.0.0.tgz#04a8698661d805ea6fa293b6cb9e63ac044ef15e"
+  integrity sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==
+  dependencies:
+    "@istanbuljs/schema" "^0.1.2"
+    glob "^7.1.4"
+    minimatch "^3.0.4"
+
 text-extensions@^1.0.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.9.0.tgz#1853e45fee39c945ce6f6c36b2d659b5aabc2a26"
@@ -4707,6 +6660,11 @@ text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
+throat@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
+  integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
 
 through2@^2.0.0, through2@^2.0.2, through2@~2.0.0:
   version "2.0.5"
@@ -4745,6 +6703,31 @@ tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
+tmpl@1.0.x:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
+  integrity sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=
+
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
+  integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
+
+to-object-path@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
+  integrity sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=
+  dependencies:
+    kind-of "^3.0.2"
+
+to-regex-range@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-2.1.1.tgz#7c80c17b9dfebe599e27367e0d4dd5590141db38"
+  integrity sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=
+  dependencies:
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
@@ -4752,13 +6735,39 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-tough-cookie@~2.5.0:
+to-regex@^3.0.1, to-regex@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
+  integrity sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==
+  dependencies:
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    regex-not "^1.0.2"
+    safe-regex "^1.1.0"
+
+tough-cookie@^2.3.3, tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
   integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
   dependencies:
     psl "^1.1.28"
     punycode "^2.1.1"
+
+tough-cookie@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-3.0.1.tgz#9df4f57e739c26930a018184887f4adb7dca73b2"
+  integrity sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==
+  dependencies:
+    ip-regex "^2.1.0"
+    psl "^1.1.28"
+    punycode "^2.1.1"
+
+tr46@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
+  integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
+  dependencies:
+    punycode "^2.1.0"
 
 traverse@~0.6.6:
   version "0.6.6"
@@ -4774,6 +6783,22 @@ trim-off-newlines@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
   integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
+
+ts-jest@^25.2.1:
+  version "25.2.1"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-25.2.1.tgz#49bf05da26a8b7fbfbc36b4ae2fcdc2fef35c85d"
+  integrity sha512-TnntkEEjuXq/Gxpw7xToarmHbAafgCaAzOpnajnFC6jI7oo1trMzAHA04eWpc3MhV6+yvhE8uUBAmN+teRJh0A==
+  dependencies:
+    bs-logger "0.x"
+    buffer-from "1.x"
+    fast-json-stable-stringify "2.x"
+    json5 "2.x"
+    lodash.memoize "4.x"
+    make-error "1.x"
+    mkdirp "0.x"
+    resolve "1.x"
+    semver "^5.5"
+    yargs-parser "^16.1.0"
 
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.1"
@@ -4806,6 +6831,11 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+type-detect@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
 type-fest@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
@@ -4825,6 +6855,13 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+typedarray-to-buffer@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
+  dependencies:
+    is-typedarray "^1.0.0"
 
 typedarray@^0.0.6:
   version "0.0.6"
@@ -4853,6 +6890,16 @@ umask@^1.1.0, umask@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
   integrity sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=
+
+union-value@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847"
+  integrity sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==
+  dependencies:
+    arr-union "^3.1.0"
+    get-value "^2.0.6"
+    is-extendable "^0.1.1"
+    set-value "^2.0.1"
 
 unique-filename@^1.1.1:
   version "1.1.1"
@@ -4906,6 +6953,14 @@ unpipe@~1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
 
+unset-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
+  integrity sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=
+  dependencies:
+    has-value "^0.3.1"
+    isobject "^3.0.0"
+
 unzip-response@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
@@ -4934,6 +6989,11 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+urix@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
+  integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
 url-join@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
@@ -4945,6 +7005,11 @@ url-parse-lax@^1.0.0:
   integrity sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=
   dependencies:
     prepend-http "^1.0.1"
+
+use@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
+  integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
@@ -4963,6 +7028,16 @@ util-promisify@^2.1.0:
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
 
+util.promisify@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.1.tgz#6baf7774b80eeb0f7520d8b81d07982a59abbaee"
+  integrity sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.2"
+    has-symbols "^1.0.1"
+    object.getownpropertydescriptors "^2.1.0"
+
 uuid@^3.3.2, uuid@^3.3.3:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
@@ -4972,6 +7047,15 @@ v8-compile-cache@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
   integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
+
+v8-to-istanbul@^4.0.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-4.1.2.tgz#387d173be5383dbec209d21af033dcb892e3ac82"
+  integrity sha512-G9R+Hpw0ITAmPSr47lSlc5A1uekSYzXxTMlFxso2xoffwo4jQnzbv1p9yXIinO8UMZKfAFewaCHwWvnH4Jb4Ug==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.1"
+    convert-source-map "^1.6.0"
+    source-map "^0.7.3"
 
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   version "3.0.4"
@@ -4997,12 +7081,61 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+w3c-hr-time@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz#0a89cdf5cc15822df9c360543676963e0cc308cd"
+  integrity sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==
+  dependencies:
+    browser-process-hrtime "^1.0.0"
+
+w3c-xmlserializer@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz#30485ca7d70a6fd052420a3d12fd90e6339ce794"
+  integrity sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==
+  dependencies:
+    domexception "^1.0.1"
+    webidl-conversions "^4.0.2"
+    xml-name-validator "^3.0.0"
+
+walker@^1.0.7, walker@~1.0.5:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
+  integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
+  dependencies:
+    makeerror "1.0.x"
+
 wcwidth@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+webidl-conversions@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
+  integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+
+whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"
+  integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
+  dependencies:
+    iconv-lite "0.4.24"
+
+whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
+  integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.1.0.tgz#c2c492f1eca612988efd3d2266be1b9fc6170d06"
+  integrity sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
 
 which-module@^2.0.0:
   version "2.0.0"
@@ -5092,6 +7225,16 @@ write-file-atomic@^2.0.0, write-file-atomic@^2.3.0, write-file-atomic@^2.4.3:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
 
+write-file-atomic@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8"
+  integrity sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==
+  dependencies:
+    imurmurhash "^0.1.4"
+    is-typedarray "^1.0.0"
+    signal-exit "^3.0.2"
+    typedarray-to-buffer "^3.1.5"
+
 write@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
@@ -5099,10 +7242,25 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
+ws@^7.0.0:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.3.tgz#a5411e1fb04d5ed0efee76d26d5c46d830c39b46"
+  integrity sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==
+
 xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
   integrity sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=
+
+xml-name-validator@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
+  integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xmlchars@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
+  integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
 xtend@~4.0.1:
   version "4.0.2"
@@ -5142,6 +7300,14 @@ yargs-parser@^10.0.0:
   integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
   dependencies:
     camelcase "^4.1.0"
+
+yargs-parser@^16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-16.1.0.tgz#73747d53ae187e7b8dbe333f95714c76ea00ecf1"
+  integrity sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
 
 yargs-parser@^18.1.1:
   version "18.1.1"
@@ -5183,7 +7349,7 @@ yargs@^11.0.0:
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
 
-yargs@^15.0.1:
+yargs@^15.0.0, yargs@^15.0.1:
   version "15.3.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
   integrity sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==


### PR DESCRIPTION
I introduce a new way to structurize definitions, which I found to work better using a recursive function to analyze the paths.
In this PR, I focused my work on bootstrapping the structuredefinitions, not really on the Attribute class because I don't really know how it will be integrated in the back/front yet, so I probably miss some features.
The `Definition` objects will be stored in redis and used in the graphql API when dealing with definitions. when serializing the definitions to JSON, the parent is omitted because having both children and parent would cause a gigantic mess.

Do you understand what's going on here of here is it too cryptic ?