### PR TITLE
Fix: Avoid item recursion when building items from this

### DIFF
--- a/src/attribute.ts
+++ b/src/attribute.ts
@@ -158,7 +158,6 @@ export class Attribute {
     serialized.slices.forEach((slice: Attribute) =>
       attr.addSlice(Attribute.from(slice)),
     )
-    serialized.items.forEach(() => attr.addItem())
     return attr
   }
 

--- a/tests/attribute.test.ts
+++ b/tests/attribute.test.ts
@@ -210,11 +210,22 @@ describe('Attribute', () => {
       slice.addChild(sliceChild2)
 
       child3.addSlice(slice)
-      child3.addItem()
-      child3.addItem()
 
       const copied = Attribute.from(parent)
-      expect(JSON.stringify(copied) === JSON.stringify(parent))
+
+      expect(JSON.stringify(copied)).toEqual(JSON.stringify(parent))
+    })
+
+    it('do not copy items', () => {
+      const attr = new Attribute(observationIdentifierDefinition)
+
+      attr.addItem()
+      attr.addItem()
+
+      expect(attr.items.length).toEqual(2)
+
+      const copied = Attribute.from(attr)
+      expect(copied.items.length).toEqual(0)
     })
 
     it('specify the parent', () => {


### PR DESCRIPTION
## Fixes
Fixes https://github.com/arkhn/pyrog/issues/457

## Description
When using addItem without the attr argument, we were using this to copy it inside itself, it's not needed to copy the array items in this case.
In other cases, the items array should be init when initializing an Attribute.

## Tests
Locally tested that everything seems to work + fixes https://github.com/arkhn/pyrog/issues/457
